### PR TITLE
HTM-963: Increase session timeout from the default 30 to 60 minutes

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,6 +42,7 @@ tailormap-api.oidc.show-for-viewer=${OIDC_SHOW_FOR_VIEWER:false}
 # in the tailormap-viewer Docker Compose stack this is changed to 0.0.0.0
 server.address=localhost
 server.http2.enabled=true
+server.servlet.session.timeout=60m
 
 # serve static frontend from this directory (/home/spring is the workdir in Dockerfile)
 spring.web.resources.static-locations=file:/home/spring/static/,classpath:/static/


### PR DESCRIPTION
Verified this works by checking `Session.getMaxActiveInterval()`.