### PR TITLE
HTM-1196: Spring Boot 3.3.3 and other dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ SPDX-License-Identifier: MIT
         <junit-jupiter.version>5.11.0</junit-jupiter.version>
         <!--        <logback.version>1.5.7</logback.version>-->
         <micrometer.version>1.13.3</micrometer.version>
-        <mssql-jdbc.version>12.8.0.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
         <oracle-database.version>23.5.0.24.07</oracle-database.version>
         <postgresql.version>42.7.3</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@ SPDX-License-Identifier: MIT
         <postgresql.version>42.7.3</postgresql.version>
         <spring-data-bom.version>2024.0.3</spring-data-bom.version>
         <spring-hateoas.version>2.3.2</spring-hateoas.version>
-        <spring-security.version>6.3.1</spring-security.version>
+        <spring-security.version>6.3.3</spring-security.version>
         <webjars-locator-core.version>0.59</webjars-locator-core.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.0</junit-jupiter.version>
         <logback.version>1.5.6</logback.version>
-        <micrometer.version>1.13.2</micrometer.version>
+        <micrometer.version>1.13.3</micrometer.version>
         <mssql-jdbc.version>12.8.0.jre11</mssql-jdbc.version>
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
         <oracle-database.version>23.5.0.24.07</oracle-database.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ SPDX-License-Identifier: MIT
             mvn -U org.codehaus.mojo:versions-maven-plugin:display-plugin-updates
         to check
         -->
-        <commons-lang3.version>3.15.0</commons-lang3.version>
+        <commons-lang3.version>3.16.0</commons-lang3.version>
         <flyway.version>10.17.0</flyway.version>
         <hibernate.version>6.5.2.Final</hibernate.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ SPDX-License-Identifier: MIT
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
         <oracle-database.version>23.5.0.24.07</oracle-database.version>
-        <postgresql.version>42.7.3</postgresql.version>
+        <postgresql.version>42.7.4</postgresql.version>
         <spring-data-bom.version>2024.0.3</spring-data-bom.version>
         <spring-hateoas.version>2.3.2</spring-hateoas.version>
         <spring-security.version>6.3.3</spring-security.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <commons-lang3.version>3.16.0</commons-lang3.version>
-        <flyway.version>10.17.1</flyway.version>
+        <flyway.version>10.17.2</flyway.version>
         <hibernate.version>6.5.2.Final</hibernate.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.0</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ SPDX-License-Identifier: MIT
         <hibernate.version>6.5.2.Final</hibernate.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.0</junit-jupiter.version>
-        <logback.version>1.5.6</logback.version>
+        <!--        <logback.version>1.5.7</logback.version>-->
         <micrometer.version>1.13.3</micrometer.version>
         <mssql-jdbc.version>12.8.0.jre11</mssql-jdbc.version>
         <okhttp.version>5.0.0-alpha.14</okhttp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <commons-lang3.version>3.16.0</commons-lang3.version>
-        <flyway.version>10.17.0</flyway.version>
+        <flyway.version>10.17.1</flyway.version>
         <hibernate.version>6.5.2.Final</hibernate.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.0</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.3.3</version>
     </parent>
     <groupId>nl.b3p.tailormap</groupId>
     <artifactId>tailormap-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@ SPDX-License-Identifier: MIT
         <oracle-database.version>23.5.0.24.07</oracle-database.version>
         <postgresql.version>42.7.3</postgresql.version>
         <spring-data-bom.version>2024.0.3</spring-data-bom.version>
-        <spring-hateoas.version>2.3.1</spring-hateoas.version>
+        <spring-hateoas.version>2.3.2</spring-hateoas.version>
         <spring-security.version>6.3.1</spring-security.version>
         <webjars-locator-core.version>0.59</webjars-locator-core.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ SPDX-License-Identifier: MIT
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
         <oracle-database.version>23.5.0.24.07</oracle-database.version>
         <postgresql.version>42.7.3</postgresql.version>
-        <spring-data-bom.version>2024.0.2</spring-data-bom.version>
+        <spring-data-bom.version>2024.0.3</spring-data-bom.version>
         <spring-hateoas.version>2.3.1</spring-hateoas.version>
         <spring-security.version>6.3.1</spring-security.version>
         <webjars-locator-core.version>0.59</webjars-locator-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@ SPDX-License-Identifier: MIT
         <spring-hateoas.version>2.3.2</spring-hateoas.version>
         <spring-security.version>6.3.3</spring-security.version>
         <webjars-locator-core.version>0.59</webjars-locator-core.version>
+        <xmlunit2.version>2.10.0</xmlunit2.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-deploy-plugin.version>3.1.0</maven-deploy-plugin.version>


### PR DESCRIPTION
[![HTM-1196](https://badgen.net/badge/JIRA/HTM-1196/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1196) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- [x] Bump `micrometer.version` from 1.13.2 to 1.13.3
- [x] Bump `commons-lang3.version` from 3.15.0 to 3.16.0
- [x] Bump `flyway.version` from 10.17.0 to 10.17.2
- [x] Bump `spring-data-bom.version` from 2024.0.2 to 2024.0.3
- [x] Bump `spring-hateoas.version` from 2.3.1 to 2.3.2
- [x] Bump `spring-security.version` from 6.3.1 to 6.3.3
- [x] Bump `org.springframework.bootspring-boot-starter-parent` from 3.3.2 to 3.3.3
- [x] Add override and bump `xmlunit2.version` to 2.10.0
- [x] Remove version override for `logback.version` as it is now up-to-date
- [x] Bump mssql-jdbc.version from 12.8.0.jre11 to 12.8.1.jre11
- [x] Bump postgresql.version from 42.7.3 to 42.7.4


resolves [HTM-1196]

this should fix:
- https://github.com/Tailormap/tailormap-api/security/dependabot/4
- https://github.com/Tailormap/tailormap-api/security/dependabot/3
- https://github.com/Tailormap/tailormap-api/security/code-scanning/349


[HTM-1196]: https://b3partners.atlassian.net/browse/HTM-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ