### PR TITLE
HTM-1039: Upgrade to GeoTools 32.0 / JTS 1.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,11 @@ SPDX-License-Identifier: MIT
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
+            <artifactId>gt-api</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
             <artifactId>gt-main</artifactId>
             <version>${geotools.version}</version>
         </dependency>
@@ -613,6 +618,10 @@ SPDX-License-Identifier: MIT
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.1.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.8.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@ SPDX-License-Identifier: MIT
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <project.build.outputTimestamp>2024-07-15T08:38:00Z</project.build.outputTimestamp>
-        <geotools.version>31.3</geotools.version>
-        <jts.version>1.19.0</jts.version>
+        <geotools.version>32-SNAPSHOT</geotools.version>
+        <jts.version>1.20.0-SNAPSHOT</jts.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>
         <!-- solr and jetty versions may need to match to prevent errors such as
         Caused by: java.lang.NoClassDefFoundError: org/eclipse/jetty/client/util/InputStreamResponseListener -->

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ SPDX-License-Identifier: MIT
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <project.build.outputTimestamp>2024-07-15T08:38:00Z</project.build.outputTimestamp>
-        <geotools.version>32-SNAPSHOT</geotools.version>
+        <geotools.version>32.0</geotools.version>
         <jts.version>1.20.0</jts.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>
         <!-- solr and jetty versions may need to match to prevent errors such as

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ SPDX-License-Identifier: MIT
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <project.build.outputTimestamp>2024-07-15T08:38:00Z</project.build.outputTimestamp>
         <geotools.version>32-SNAPSHOT</geotools.version>
-        <jts.version>1.20.0-SNAPSHOT</jts.version>
+        <jts.version>1.20.0</jts.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>
         <!-- solr and jetty versions may need to match to prevent errors such as
         Caused by: java.lang.NoClassDefFoundError: org/eclipse/jetty/client/util/InputStreamResponseListener -->


### PR DESCRIPTION
[![HTM-1039](https://badgen.net/badge/JIRA/HTM-1039/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1039) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Releases are expected first half of September, see [GeoServer Release Schedule](https://github.com/geoserver/geoserver/wiki/Release-Schedule) and [JTS release plan](https://projects.eclipse.org/projects/locationtech.jts/releases/1.20.0/plan)

- [x] try GeoTools 32-SNAPSHOT and JTS 1.20.0-SNAPSHOT
- [x] Bump JTS from 1.20.0-SNAPSHOT to 1.20.0
- [ ] ~~Bump GeoTools to 32-RC~~
- [x] Bump GeoTools to 32.0

see also: https://github.com/geoserver/geoserver/wiki/Release-Schedule#volunteer-coordination

[HTM-1039]: https://b3partners.atlassian.net/browse/HTM-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ