### PR TITLE
Bump org.apache.commons:commons-lang3 from 3.16.0 to 3.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ SPDX-License-Identifier: MIT
             mvn -U org.codehaus.mojo:versions-maven-plugin:display-plugin-updates
         to check
         -->
-        <commons-lang3.version>3.16.0</commons-lang3.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
         <flyway.version>10.17.2</flyway.version>
         <hibernate.version>6.5.2.Final</hibernate.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>


### PR DESCRIPTION
Bumps org.apache.commons:commons-lang3 from 3.16.0 to 3.17.0.