### PR TITLE
Disable LayerExportControllerIntegrationTest#shouldNotExportHiddenAttributesInGeoJSON

### DIFF
--- a/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
@@ -198,7 +198,7 @@ class LayerExportControllerIntegrationTest {
 
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  @Ignore("https://b3partners.atlassian.net/browse/HTM-1198")
+  @Disabled("https://b3partners.atlassian.net/browse/HTM-1198")
   void shouldNotExportHiddenAttributesInGeoJSONWhenRequested() throws Exception {
     final String url = apiBasePath + begroeidterreindeel;
     mockMvc

--- a/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.tailormap.api.TestRequestProcessor.setServletPath;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -197,6 +198,7 @@ class LayerExportControllerIntegrationTest {
 
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  @Ignore("https://b3partners.atlassian.net/browse/HTM-1198")
   void shouldNotExportHiddenAttributesInGeoJSONWhenRequested() throws Exception {
     final String url = apiBasePath + begroeidterreindeel;
     mockMvc

--- a/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
@@ -198,7 +198,6 @@ class LayerExportControllerIntegrationTest {
 
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  @Disabled("https://b3partners.atlassian.net/browse/HTM-1198")
   void shouldNotExportHiddenAttributesInGeoJSONWhenRequested() throws Exception {
     final String url = apiBasePath + begroeidterreindeel;
     mockMvc
@@ -219,6 +218,7 @@ class LayerExportControllerIntegrationTest {
 
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  @Disabled("https://b3partners.atlassian.net/browse/HTM-1198")
   void shouldNotExportHiddenAttributesInGeoJSON() throws Exception {
     final String url = apiBasePath + begroeidterreindeel;
     mockMvc


### PR DESCRIPTION
as tracked in https://b3partners.atlassian.net/browse/HTM-1198 this may be caused by a behavioural change in GeoServer