### PR TITLE
Generate sources before running CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' ) && format('ci-main-{0}', github.sha) || format('ci-main-{0}', github.ref) }}
   cancel-in-progress: true
 
+env:
+  MAVEN_OPTS: -Djava.awt.headless=true
+  MAVEN_VERSION: '3.9.9'
+
 on:
   push:
     branches: [ main ]
@@ -41,6 +45,14 @@ jobs:
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v4
+
+      - name: 'Set up Maven'
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: ${{ env.MAVEN_VERSION }}
+
+      - name: 'Generate sources with Maven'
+        run: mvn generate-sources
 
       - name: 'Initialize CodeQL'
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,12 @@ jobs:
       - name: 'Checkout repository'
         uses: actions/checkout@v4
 
+      - name: 'Set up JDK'
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
       - name: 'Set up Maven'
         uses: stCarolas/setup-maven@v5
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     name: 'CodeQL Analyze'
     runs-on: 'ubuntu-latest'
     # don't run on pull request merges to main from dependabot as these will always fail
-    if: ${{ (github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/main') }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     name: 'CodeQL Analyze'
     runs-on: 'ubuntu-latest'
     # don't run on pull request merges to main from dependabot as these will always fail
-    if: ${{ github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/main' }}
+    if: ${{ (github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/main') }}
     permissions:
       security-events: write
       actions: read


### PR DESCRIPTION
The tool complains about 'Low Java analysis quality' after https://github.com/Tailormap/tailormap-api/pull/929

> Scanning Java code completed successfully, but the scan encountered issues. This may be caused by problems identifying dependencies or use of generated source code, among other reasons -- see other CodeQL diagnostics reported on the CodeQL status page for more details of possible causes. Addressing these warnings is advisable to avoid false-positive or missing results. If they cannot be addressed, consider scanning Java using either the autobuild or manual [build modes](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages#comparison-of-the-build-modes).