### PR TITLE
HTM-1162: Configure logfile so it can be retrieved using actuator

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -9,6 +9,10 @@ server.error.include-message=always
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.properties.hibernate.use_sql_comments=true
+#spring.jpa.properties.hibernate.enable_metrics=false
+#spring.jpa.properties.hibernate.generate_statistics=false
+
+logging.file.name=
 
 #logging.level.org.springframework=DEBUG
 #logging.level.org.springframework.boot=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -65,8 +65,6 @@ spring.datasource.password=tailormap
 spring.datasource.pool-size=30
 
 spring.jpa.open-in-view=false
-spring.jpa.properties.hibernate.enable_metrics=true
-spring.jpa.properties.hibernate.generate_statistics=true
 
 spring.data.rest.base-path=/api/admin
 spring.data.rest.detection-strategy=default
@@ -87,7 +85,6 @@ management.endpoints.enabled-by-default=false
 management.endpoints.web.base-path=/api/actuator
 management.endpoints.web.exposure.include=info,health,prometheus,loggers,logfile,mappings
 
-# we don't have a logfile configured, so this will return 404
 management.endpoint.logfile.enabled=true
 # NOTE this `loggers` is an endpoint that can change the configuration while running using POST requests
 management.endpoint.loggers.enabled=true
@@ -105,21 +102,9 @@ management.metrics.data.repository.autotime.percentiles=0.5,0.95,0.99
 management.prometheus.metrics.export.enabled=true
 management.prometheus.metrics.export.descriptions=true
 
-logging.level.org.springframework.boot=INFO
-logging.level.org.springframework.boot.autoconfigure=INFO
-logging.level.org.springframework.test.context=INFO
+# Create logfile in current directory
+logging.file.name=tailormap.log
+logging.include-application-name=false
 
-logging.level.org.hibernate=INFO
-logging.level.org.hibernate.SQL=INFO
-logging.level.org.hibernate.engine.jdbc.spi.SqlExceptionHelper=ERROR
-
-logging.level.org.flywaydb.core.internal.license=ERROR
-
-# no hibernate session metrics in the log
-logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener=OFF
-# we don't use jTDS
-logging.level.org.geotools.data.sqlserver.jtds=OFF
-
-logging.level.org.tailormap.api=DEBUG
-
-logging.level.org.tailormap.api.persistence.helper.GeoServiceHelper=INFO
+logging.group.tailormap=org.tailormap
+logging.group.geotools=org.geotools


### PR DESCRIPTION
[![HTM-1162](https://badgen.net/badge/JIRA/HTM-1162/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1162) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Also make the logging config for the default profile more appropriate for production use.

The default log rotation settings are used:
https://docs.spring.io/spring-boot/reference/features/logging.html#features.logging.file-rotation

[HTM-1162]: https://b3partners.atlassian.net/browse/HTM-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ