### PR TITLE
Revert "Bump org.apache.maven.plugins:maven-scm-publish-plugin from 3.2.1 to 3.3.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -599,7 +599,7 @@ SPDX-License-Identifier: MIT
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
Reverts Tailormap/tailormap-api#857

see https://github.com/B3Partners/jdbc-util/pull/630