### PR TITLE
HTM-1206: disable Solr indexing for WFS feature types

### DIFF
--- a/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
@@ -186,6 +186,8 @@ public class SolrAdminController {
                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Feature type not found"));
 
     if (TMFeatureSource.Protocol.WFS.equals(indexingFT.getFeatureSource().getProtocol())) {
+      // the search index should not exist for WFS feature types, but just in case
+      searchIndex.setStatus(SearchIndex.Status.ERROR).setComment("WFS indexing not supported");
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Layer does not have valid feature type for indexing");
     }

--- a/src/main/java/org/tailormap/api/repository/validation/SearchIndexValidator.java
+++ b/src/main/java/org/tailormap/api/repository/validation/SearchIndexValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.repository.validation;
+
+import java.lang.invoke.MethodHandles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.tailormap.api.persistence.SearchIndex;
+import org.tailormap.api.persistence.TMFeatureSource;
+import org.tailormap.api.repository.FeatureTypeRepository;
+
+@Component
+public class SearchIndexValidator implements Validator {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final FeatureTypeRepository featureTypeRepository;
+
+  public SearchIndexValidator(FeatureTypeRepository featureTypeRepository) {
+    this.featureTypeRepository = featureTypeRepository;
+  }
+
+  @Override
+  public boolean supports(@NonNull Class<?> clazz) {
+    return SearchIndex.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(@NonNull Object target, @NonNull Errors errors) {
+    final SearchIndex searchIndex = (SearchIndex) target;
+    if (searchIndex.getFeatureTypeId() != null) {
+      featureTypeRepository
+          .findById(searchIndex.getFeatureTypeId())
+          .ifPresent(
+              (ft) -> {
+                if (TMFeatureSource.Protocol.WFS.equals(ft.getFeatureSource().getProtocol())) {
+                  logger.warn(
+                      "Attempt to index feature type '{}' from unsupported WFS source '{}'.",
+                      ft.getName(),
+                      ft.getFeatureSource().getTitle());
+                  errors.rejectValue(
+                      "featureTypeId",
+                      "invalid",
+                      "This feature type is not available for indexing.");
+                }
+              });
+    }
+  }
+}

--- a/src/main/java/org/tailormap/api/repository/validation/ValidationConfiguration.java
+++ b/src/main/java/org/tailormap/api/repository/validation/ValidationConfiguration.java
@@ -22,27 +22,34 @@ public class ValidationConfiguration implements RepositoryRestConfigurer {
 
   private final ApplicationValidator applicationValidator;
 
+  private final SearchIndexValidator searchIndexValidator;
+
   public ValidationConfiguration(
       LocalValidatorFactoryBean localValidatorFactoryBean,
       GeoServiceValidator geoServiceValidator,
       FeatureSourceValidator featureSourceValidator,
-      ApplicationValidator applicationValidator) {
+      ApplicationValidator applicationValidator,
+      SearchIndexValidator searchIndexValidator) {
     this.localValidatorFactoryBean = localValidatorFactoryBean;
     this.geoServiceValidator = geoServiceValidator;
     this.featureSourceValidator = featureSourceValidator;
     this.applicationValidator = applicationValidator;
+    this.searchIndexValidator = searchIndexValidator;
   }
 
   @Override
   public void configureValidatingRepositoryEventListener(
       ValidatingRepositoryEventListener validatingListener) {
-    validatingListener.addValidator("beforeCreate", localValidatorFactoryBean);
-    validatingListener.addValidator("beforeSave", localValidatorFactoryBean);
-    validatingListener.addValidator("beforeCreate", geoServiceValidator);
-    validatingListener.addValidator("beforeSave", geoServiceValidator);
-    validatingListener.addValidator("beforeCreate", featureSourceValidator);
-    validatingListener.addValidator("beforeSave", featureSourceValidator);
-    validatingListener.addValidator("beforeCreate", applicationValidator);
-    validatingListener.addValidator("beforeSave", applicationValidator);
+    validatingListener
+        .addValidator("beforeCreate", localValidatorFactoryBean)
+        .addValidator("beforeSave", localValidatorFactoryBean)
+        .addValidator("beforeCreate", geoServiceValidator)
+        .addValidator("beforeSave", geoServiceValidator)
+        .addValidator("beforeCreate", featureSourceValidator)
+        .addValidator("beforeSave", featureSourceValidator)
+        .addValidator("beforeCreate", applicationValidator)
+        .addValidator("beforeSave", applicationValidator)
+        .addValidator("beforeCreate", searchIndexValidator)
+        .addValidator("beforeSave", searchIndexValidator);
   }
 }

--- a/src/test/java/org/tailormap/api/repository/validation/SearchIndexValidatorIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/repository/validation/SearchIndexValidatorIntegrationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.repository.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.tailormap.api.annotation.PostgresIntegrationTest;
+import org.tailormap.api.persistence.SearchIndex;
+import org.tailormap.api.repository.FeatureTypeRepository;
+
+@PostgresIntegrationTest
+class SearchIndexValidatorIntegrationTest {
+  private SearchIndexValidator searchIndexValidator;
+
+  @Autowired private FeatureTypeRepository featureTypeRepository;
+
+  @BeforeEach
+  void setUp() {
+    searchIndexValidator = new SearchIndexValidator(featureTypeRepository);
+  }
+
+  @Test
+  void supports() {
+    assertTrue(searchIndexValidator.supports(SearchIndex.class));
+    assertFalse(searchIndexValidator.supports(Object.class));
+  }
+
+  @Test
+  void testWFSFeatureType() {
+    SearchIndex wfsIndex = new SearchIndex().setFeatureTypeId(15L);
+    Errors errors = new BeanPropertyBindingResult(wfsIndex, "");
+    searchIndexValidator.validate(wfsIndex, errors);
+
+    assertEquals(1, errors.getErrorCount(), "Expected 1 error");
+    assertEquals(
+        "This feature type is not available for indexing.",
+        errors.getAllErrors().get(0).getDefaultMessage(),
+        "Did not get expected error message");
+  }
+
+  @Test
+  void testJDBCFeatureType() {
+    SearchIndex wfsIndex = new SearchIndex().setFeatureTypeId(26L);
+    Errors errors = new BeanPropertyBindingResult(wfsIndex, "");
+    searchIndexValidator.validate(wfsIndex, errors);
+
+    assertEquals(0, errors.getErrorCount(), "Expected no errors");
+  }
+}


### PR DESCRIPTION
[![HTM-1206](https://badgen.net/badge/JIRA/HTM-1206/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1206) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Throw an error when a request to index a WFS feature type is received in the indexing controller, this should never happen because it should not be possible to create an index in a wfs feature type.

When you try to create a search index on a wfs:

```javascript
fetch("http://localhost:8080/api/admin/search-indexes", {
  "headers": {
    "accept": "application/json, text/plain, */*",
    "accept-language": "nl,en-AU;q=0.9,en-GB;q=0.8,en;q=0.7,de;q=0.6",
    "content-type": "application/json",
    "x-xsrf-token": "f9d0e7ea-2188-449b-9509-693d46e6b584"
  },
  "referrer": "https://snapshot.tailormap.nl/nl/admin/search-indexes/create",
  "referrerPolicy": "strict-origin-when-cross-origin",
  "body": "{\"name\":\"afzettingenWFS\",\"comment\":\"\",\"featureTypeId\":15,\"searchFieldsUsed\":[],\"searchDisplayFieldsUsed\":[],\"status\":\"INITIAL\",\"lastIndexed\":null}",
  "method": "POST",
  "mode": "cors",
  "credentials": "include"
});
```


The response is:

```json
{
    "errors": [
        {
            "entity": "SearchIndex",
            "property": "featureTypeId",
            "invalidValue": 15,
            "message": "This feature type is not available for indexing."
        }
    ]
}
```
with response status code `400 Bad Request`.

A warning log message will be logged: "Attempt to index feature type 'geodata:archeologie_afzettingen' from unsupported WFS source 'WFS for Demo'."

[HTM-1206]: https://b3partners.atlassian.net/browse/HTM-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ