### PR TITLE
HTM-1211: Some code improvements for Solr functionality

### DIFF
--- a/src/main/java/org/tailormap/api/controller/SearchController.java
+++ b/src/main/java/org/tailormap/api/controller/SearchController.java
@@ -12,10 +12,8 @@ import io.micrometer.core.annotation.Timed;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.TimeUnit;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.common.SolrException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +35,7 @@ import org.tailormap.api.persistence.json.AppLayerSettings;
 import org.tailormap.api.persistence.json.AppTreeLayerNode;
 import org.tailormap.api.repository.SearchIndexRepository;
 import org.tailormap.api.solr.SolrHelper;
+import org.tailormap.api.solr.SolrService;
 import org.tailormap.api.viewer.model.SearchResponse;
 
 @AppRestController
@@ -49,18 +48,14 @@ public class SearchController {
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final SearchIndexRepository searchIndexRepository;
-
-  @Value("${tailormap-api.solr-url}")
-  private String solrUrl;
-
-  @Value("${tailormap-api.solr-core-name:tailormap}")
-  private String solrCoreName;
+  private final SolrService solrService;
 
   @Value("${tailormap-api.pageSize:100}")
   private int numResultsToReturn;
 
-  public SearchController(SearchIndexRepository searchIndexRepository) {
+  public SearchController(SearchIndexRepository searchIndexRepository, SolrService solrService) {
     this.searchIndexRepository = searchIndexRepository;
+    this.solrService = solrService;
   }
 
   @Transactional(readOnly = true)
@@ -92,7 +87,7 @@ public class SearchController {
                         "Layer '%s' does not have a search index"
                             .formatted(appTreeLayerNode.getLayerName())));
 
-    try (SolrClient solrClient = getSolrClient();
+    try (SolrClient solrClient = solrService.getSolrClientForSearching();
         SolrHelper solrHelper = new SolrHelper(solrClient)) {
       final SearchResponse searchResponse =
           solrHelper.findInIndex(searchIndex, solrQuery, start, numResultsToReturn);
@@ -108,12 +103,5 @@ public class SearchController {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Error while searching with given query", e);
     }
-  }
-
-  private SolrClient getSolrClient() {
-    return new Http2SolrClient.Builder(solrUrl + solrCoreName)
-        .withConnectionTimeout(10, TimeUnit.SECONDS)
-        .withFollowRedirects(true)
-        .build();
   }
 }

--- a/src/main/java/org/tailormap/api/repository/FeatureSourceRepository.java
+++ b/src/main/java/org/tailormap/api/repository/FeatureSourceRepository.java
@@ -51,4 +51,14 @@ public interface FeatureSourceRepository extends JpaRepository<TMFeatureSource, 
   @PreAuthorize("permitAll()")
   @Query("from TMFeatureSource fs where id not in :ids")
   List<TMFeatureSource> getAllExcludingIds(@Param("ids") List<Long> ids);
+
+  /**
+   * Find a feature-source by title. This is a non-deterministic operation since the title is not
+   * unique. Useful for testing.
+   *
+   * @param title The title of the feature-source
+   * @return The feature-source
+   */
+  @PreAuthorize(value = "permitAll()")
+  Optional<TMFeatureSource> getByTitle(String title);
 }

--- a/src/main/java/org/tailormap/api/repository/FeatureTypeRepository.java
+++ b/src/main/java/org/tailormap/api/repository/FeatureTypeRepository.java
@@ -5,12 +5,28 @@
  */
 package org.tailormap.api.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.tailormap.api.persistence.TMFeatureSource;
 import org.tailormap.api.persistence.TMFeatureType;
 
 @RepositoryRestResource(
     path = "feature-types",
     collectionResourceRel = "feature-types",
     itemResourceRel = "feature-type")
-public interface FeatureTypeRepository extends JpaRepository<TMFeatureType, Long> {}
+public interface FeatureTypeRepository extends JpaRepository<TMFeatureType, Long> {
+
+  /**
+   * Get a feature type by name and feature source. This is a non-deterministic operation since the
+   * combination of name and feature source is not unique. Useful for testing.
+   *
+   * @param name The name of the feature type
+   * @param featureSource The feature source of the feature type
+   * @return The feature type
+   */
+  @PreAuthorize("permitAll()")
+  Optional<TMFeatureType> getTMFeatureTypeByNameAndFeatureSource(
+      String name, TMFeatureSource featureSource);
+}

--- a/src/main/java/org/tailormap/api/solr/SolrHelper.java
+++ b/src/main/java/org/tailormap/api/solr/SolrHelper.java
@@ -190,7 +190,10 @@ public class SolrHelper implements AutoCloseable, Constants {
           docsBatch.clear();
         }
       }
+    } finally {
+      if (fs.getDataStore() != null) fs.getDataStore().dispose();
     }
+
     if (!docsBatch.isEmpty()) {
       updateResponse = solrClient.addBeans(docsBatch);
       logger.info("Added last {} documents of {} to index", docsBatch.size(), total);

--- a/src/main/java/org/tailormap/api/solr/SolrHelper.java
+++ b/src/main/java/org/tailormap/api/solr/SolrHelper.java
@@ -258,8 +258,8 @@ public class SolrHelper implements AutoCloseable, Constants {
     if (null == solrQuery || solrQuery.isBlank()) {
       solrQuery = "*";
     }
-    // TODO We could escape special/syntax characters, but that also prevents using keys like ~ and
-    // *
+    // TODO We could escape special/syntax characters, but that also prevents using
+    //      keys like ~ and *
     // solrQuery = ClientUtils.escapeQueryChars(solrQuery);
 
     final SolrQuery query =

--- a/src/main/java/org/tailormap/api/solr/SolrService.java
+++ b/src/main/java/org/tailormap/api/solr/SolrService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.solr;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.ConcurrentUpdateHttp2SolrClient;
+import org.apache.solr.client.solrj.impl.Http2SolrClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SolrService {
+  @Value("${tailormap-api.solr-url}")
+  private String solrUrl;
+
+  @Value("${tailormap-api.solr-core-name:tailormap}")
+  private String solrCoreName;
+
+  /**
+   * Get a concurrent update Solr client for bulk operations.
+   *
+   * @return the Solr client
+   */
+  public SolrClient getSolrClientForIndexing() {
+    return new ConcurrentUpdateHttp2SolrClient.Builder(
+            this.solrUrl + this.solrCoreName,
+            new Http2SolrClient.Builder()
+                .withFollowRedirects(true)
+                .withConnectionTimeout(10000, TimeUnit.MILLISECONDS)
+                .withRequestTimeout(60000, TimeUnit.MILLISECONDS)
+                .build())
+        .withQueueSize(SolrHelper.SOLR_BATCH_SIZE * 2)
+        .withThreadCount(10)
+        .build();
+  }
+
+  /**
+   * Get a Solr client for searching.
+   *
+   * @return the Solr client
+   */
+  public SolrClient getSolrClientForSearching() {
+    return new Http2SolrClient.Builder(this.solrUrl + this.solrCoreName)
+        .withConnectionTimeout(10, TimeUnit.SECONDS)
+        .withFollowRedirects(true)
+        .build();
+  }
+
+  public void setSolrUrl(String solrUrl) {
+    this.solrUrl = solrUrl;
+  }
+}

--- a/src/test/java/org/tailormap/api/repository/validation/SearchIndexValidatorIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/repository/validation/SearchIndexValidatorIntegrationTest.java
@@ -8,6 +8,7 @@ package org.tailormap.api.repository.validation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.Errors;
 import org.tailormap.api.annotation.PostgresIntegrationTest;
 import org.tailormap.api.persistence.SearchIndex;
+import org.tailormap.api.repository.FeatureSourceRepository;
 import org.tailormap.api.repository.FeatureTypeRepository;
 
 @PostgresIntegrationTest
@@ -23,6 +25,7 @@ class SearchIndexValidatorIntegrationTest {
   private SearchIndexValidator searchIndexValidator;
 
   @Autowired private FeatureTypeRepository featureTypeRepository;
+  @Autowired private FeatureSourceRepository featureSourceRepository;
 
   @BeforeEach
   void setUp() {
@@ -36,24 +39,51 @@ class SearchIndexValidatorIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testWFSFeatureType() {
-    SearchIndex wfsIndex = new SearchIndex().setFeatureTypeId(15L);
-    Errors errors = new BeanPropertyBindingResult(wfsIndex, "");
-    searchIndexValidator.validate(wfsIndex, errors);
-
-    assertEquals(1, errors.getErrorCount(), "Expected 1 error");
-    assertEquals(
-        "This feature type is not available for indexing.",
-        errors.getAllErrors().get(0).getDefaultMessage(),
-        "Did not get expected error message");
+    featureSourceRepository
+        .getByTitle("WFS for Test GeoServer")
+        .ifPresentOrElse(
+            featureSource -> {
+              featureTypeRepository
+                  .getTMFeatureTypeByNameAndFeatureSource(
+                      "postgis:begroeidterreindeel", featureSource)
+                  .ifPresentOrElse(
+                      featureType -> {
+                        SearchIndex wfsIndex =
+                            new SearchIndex().setFeatureTypeId(featureType.getId());
+                        Errors errors = new BeanPropertyBindingResult(wfsIndex, "");
+                        searchIndexValidator.validate(wfsIndex, errors);
+                        assertEquals(1, errors.getErrorCount(), "Expected 1 error");
+                        assertEquals(
+                            "This feature type is not available for indexing.",
+                            errors.getAllErrors().get(0).getDefaultMessage(),
+                            "Did not get expected error message");
+                      },
+                      () -> fail("Feature type not found"));
+            },
+            () -> fail("Feature source not found"));
   }
 
   @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
   void testJDBCFeatureType() {
-    SearchIndex wfsIndex = new SearchIndex().setFeatureTypeId(26L);
-    Errors errors = new BeanPropertyBindingResult(wfsIndex, "");
-    searchIndexValidator.validate(wfsIndex, errors);
-
-    assertEquals(0, errors.getErrorCount(), "Expected no errors");
+    featureSourceRepository
+        .getByTitle("PostGIS")
+        .ifPresentOrElse(
+            featureSource -> {
+              featureTypeRepository
+                  .getTMFeatureTypeByNameAndFeatureSource("begroeidterreindeel", featureSource)
+                  .ifPresentOrElse(
+                      featureType -> {
+                        SearchIndex jdbcIndex =
+                            new SearchIndex().setFeatureTypeId(featureType.getId());
+                        Errors errors = new BeanPropertyBindingResult(jdbcIndex, "");
+                        searchIndexValidator.validate(jdbcIndex, errors);
+                        assertEquals(0, errors.getErrorCount(), "Expected no errors");
+                      },
+                      () -> fail("Feature type not found"));
+            },
+            () -> fail("Feature source not found"));
   }
 }


### PR DESCRIPTION
- Introduce the SolrService from PR #844
- make the SearchIndexValidatorIntegrationTest more robust to changes and differences in the persisted test data 
- resolve GeoTools logging the message "There's code using JDBC based datastore and not disposing them. This may lead to temporary loss of database connections. Please make sure all data access code calls DataStore.dispose() before freeing all references to it" by explicitly calling `dispose()`.
