### PR TITLE
HTM-1254|HTM-1255|HTM-1256|HTM-1257: Make creating full-text indexes on schedule as part of task framework possible

### DIFF
--- a/src/main/java/org/tailormap/api/configuration/base/WebMvcConfig.java
+++ b/src/main/java/org/tailormap/api/configuration/base/WebMvcConfig.java
@@ -6,7 +6,6 @@
 
 package org.tailormap.api.configuration.base;
 
-import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
@@ -17,13 +16,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.resource.EncodedResourceResolver;
 import org.tailormap.api.configuration.CaseInsensitiveEnumConverter;
 import org.tailormap.api.persistence.json.GeoServiceProtocol;
+import org.tailormap.api.scheduling.TaskType;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
+  private final IndexHtmlTransformer indexHtmlTransformer;
+
   @Value("${spring.web.resources.static-locations:file:/home/spring/static/}")
   private String resourceLocations;
-
-  private final IndexHtmlTransformer indexHtmlTransformer;
 
   public WebMvcConfig(IndexHtmlTransformer indexHtmlTransformer) {
     this.indexHtmlTransformer = indexHtmlTransformer;
@@ -53,10 +53,12 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
   @Override
   public void addFormatters(@NonNull FormatterRegistry registry) {
-    List.of(GeoServiceProtocol.class)
-        .forEach(
-            enumClass ->
-                registry.addConverter(
-                    String.class, enumClass, new CaseInsensitiveEnumConverter<>(enumClass)));
+    registry.addConverter(
+        String.class,
+        GeoServiceProtocol.class,
+        new CaseInsensitiveEnumConverter<>(GeoServiceProtocol.class));
+
+    registry.addConverter(
+        String.class, TaskType.class, new CaseInsensitiveEnumConverter<>(TaskType.class));
   }
 }

--- a/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
@@ -76,11 +76,13 @@ import org.tailormap.api.repository.GroupRepository;
 import org.tailormap.api.repository.SearchIndexRepository;
 import org.tailormap.api.repository.UploadRepository;
 import org.tailormap.api.repository.UserRepository;
+import org.tailormap.api.scheduling.FailingPocTask;
 import org.tailormap.api.scheduling.IndexTask;
 import org.tailormap.api.scheduling.PocTask;
 import org.tailormap.api.scheduling.TMJobDataMap;
 import org.tailormap.api.scheduling.Task;
 import org.tailormap.api.scheduling.TaskManagerService;
+import org.tailormap.api.scheduling.TaskType;
 import org.tailormap.api.security.InternalAdminAuthentication;
 import org.tailormap.api.solr.SolrHelper;
 import org.tailormap.api.solr.SolrService;
@@ -1531,9 +1533,9 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
               new TMJobDataMap(
                   Map.of(
                       Task.TYPE_KEY,
-                      PocTask.TYPE,
+                      TaskType.POC.getValue(),
                       "foo",
-                      "bar",
+                      "foobar",
                       Task.DESCRIPTION_KEY,
                       "POC task that runs every minute")),
               /* run every 15 minutes */ "0 0/15 * 1/1 * ? *"));
@@ -1544,13 +1546,27 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
               new TMJobDataMap(
                   Map.of(
                       Task.TYPE_KEY,
-                      PocTask.TYPE,
+                      TaskType.POC.getValue(),
                       "foo",
                       "bar",
                       Task.DESCRIPTION_KEY,
                       "POC task that runs every hour",
                       Task.PRIORITY_KEY,
                       10)),
+              /* run every hour */ "0 0 0/1 1/1 * ? *"));
+
+      logger.info(
+          "Created hourly failing task with key: {}",
+          taskManagerService.createTask(
+              FailingPocTask.class,
+              new TMJobDataMap(
+                  Map.of(
+                      Task.TYPE_KEY,
+                      TaskType.FAILINGPOC.getValue(),
+                      Task.DESCRIPTION_KEY,
+                      "POC task that fails every hour with low priority",
+                      Task.PRIORITY_KEY,
+                      100)),
               /* run every hour */ "0 0 0/1 1/1 * ? *"));
     } catch (SchedulerException e) {
       logger.error("Error creating scheduled poc tasks", e);
@@ -1565,8 +1581,8 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
                   new TaskSchedule()
                       /* hour */
                       .cronExpression("0 0 0/1 1/1 * ? *")
-                      //                      /* 15 min */
-                      //                      .cronExpression("0 0/15 * 1/1 * ? *")
+                      // /* 15 min */
+                      // .cronExpression("0 0/15 * 1/1 * ? *")
                       .description("Update Solr index \"Begroeidterreindeel\" every time"));
               try {
                 final UUID uuid =
@@ -1575,7 +1591,7 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
                         new TMJobDataMap(
                             Map.of(
                                 Task.TYPE_KEY,
-                                IndexTask.TYPE,
+                                TaskType.INDEX,
                                 Task.DESCRIPTION_KEY,
                                 index.getSchedule().getDescription(),
                                 IndexTask.INDEX_KEY,

--- a/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
@@ -79,7 +79,8 @@ import org.tailormap.api.repository.UserRepository;
 import org.tailormap.api.scheduling.IndexTask;
 import org.tailormap.api.scheduling.PocTask;
 import org.tailormap.api.scheduling.TMJobDataMap;
-import org.tailormap.api.scheduling.TaskCreator;
+import org.tailormap.api.scheduling.Task;
+import org.tailormap.api.scheduling.TaskManagerService;
 import org.tailormap.api.security.InternalAdminAuthentication;
 import org.tailormap.api.solr.SolrHelper;
 import org.tailormap.api.solr.SolrService;
@@ -104,7 +105,7 @@ public class PopulateTestData {
   private final GeoServiceRepository geoServiceRepository;
   private final GeoServiceHelper geoServiceHelper;
   private final SolrService solrService;
-  private final TaskCreator taskCreator;
+  private final TaskManagerService taskManagerService;
   private final FeatureSourceRepository featureSourceRepository;
   private final ApplicationRepository applicationRepository;
   private final ConfigurationRepository configurationRepository;
@@ -135,7 +136,7 @@ public class PopulateTestData {
       GeoServiceRepository geoServiceRepository,
       GeoServiceHelper geoServiceHelper,
       SolrService solrService,
-      TaskCreator taskCreator,
+      TaskManagerService taskManagerService,
       FeatureSourceRepository featureSourceRepository,
       ApplicationRepository applicationRepository,
       ConfigurationRepository configurationRepository,
@@ -149,7 +150,7 @@ public class PopulateTestData {
     this.geoServiceRepository = geoServiceRepository;
     this.geoServiceHelper = geoServiceHelper;
     this.solrService = solrService;
-    this.taskCreator = taskCreator;
+    this.taskManagerService = taskManagerService;
     this.featureSourceRepository = featureSourceRepository;
     this.applicationRepository = applicationRepository;
     this.configurationRepository = configurationRepository;
@@ -1525,27 +1526,30 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
       logger.info("Creating POC tasks");
       logger.info(
           "Created minutely task with key: {}",
-          taskCreator.createTask(
+          taskManagerService.createTask(
               PocTask.class,
               new TMJobDataMap(
                   Map.of(
-                      "type", PocTask.TYPE,
-                      "foo", "bar",
-                      "description", "POC task that runs every minute")),
-              /* run every 15 minutes */ "0 0/15 * 1/1 * ? *"));
-      logger.info(
-          "Created hourly task with key: {}",
-          taskCreator.createTask(
-              PocTask.class,
-              new TMJobDataMap(
-                  Map.of(
-                      "type",
+                      Task.TYPE_KEY,
                       PocTask.TYPE,
                       "foo",
                       "bar",
-                      "description",
+                      Task.DESCRIPTION_KEY,
+                      "POC task that runs every minute")),
+              /* run every 15 minutes */ "0 0/15 * 1/1 * ? *"));
+      logger.info(
+          "Created hourly task with key: {}",
+          taskManagerService.createTask(
+              PocTask.class,
+              new TMJobDataMap(
+                  Map.of(
+                      Task.TYPE_KEY,
+                      PocTask.TYPE,
+                      "foo",
+                      "bar",
+                      Task.DESCRIPTION_KEY,
                       "POC task that runs every hour",
-                      "priority",
+                      Task.PRIORITY_KEY,
                       10)),
               /* run every hour */ "0 0 0/1 1/1 * ? *"));
     } catch (SchedulerException e) {
@@ -1566,17 +1570,17 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
                       .description("Update Solr index \"Begroeidterreindeel\" every time"));
               try {
                 final UUID uuid =
-                    taskCreator.createTask(
+                    taskManagerService.createTask(
                         IndexTask.class,
                         new TMJobDataMap(
                             Map.of(
-                                "type",
+                                Task.TYPE_KEY,
                                 IndexTask.TYPE,
-                                "description",
+                                Task.DESCRIPTION_KEY,
                                 index.getSchedule().getDescription(),
-                                "index",
+                                IndexTask.INDEX_KEY,
                                 index.getId().toString(),
-                                "priority",
+                                Task.PRIORITY_KEY,
                                 10)),
                         index.getSchedule().getCronExpression());
 

--- a/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
@@ -126,7 +126,7 @@ public class SolrAdminController {
                   @Schema(
                       example = "{\"message\":\"Layer does not have feature type\",\"code\":404}")))
   @ApiResponse(
-      responseCode = "404",
+      responseCode = "400",
       description = "Indexing WFS feature types is not supported",
       content =
           @Content(
@@ -173,7 +173,9 @@ public class SolrAdminController {
             || searchIndex.getStatus() == SearchIndex.Status.INITIAL);
     try (SolrClient solrClient = solrService.getSolrClientForIndexing();
         SolrHelper solrHelper = new SolrHelper(solrClient)) {
-      solrHelper.addFeatureTypeIndex(searchIndex, indexingFT, featureSourceFactoryHelper);
+      searchIndex =
+          solrHelper.addFeatureTypeIndex(
+              searchIndex, indexingFT, featureSourceFactoryHelper, searchIndexRepository);
       searchIndexRepository.save(searchIndex);
     } catch (UnsupportedOperationException | IOException | SolrServerException | SolrException e) {
       logger.error("Error indexing", e);

--- a/src/main/java/org/tailormap/api/controller/admin/TaskAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/TaskAdminController.java
@@ -46,6 +46,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import org.tailormap.api.scheduling.Task;
 import org.tailormap.api.scheduling.TaskManagerService;
+import org.tailormap.api.scheduling.TaskType;
 
 /**
  * Admin controller for controlling the task scheduler. Not to be used to create new tasks, adding
@@ -190,7 +191,7 @@ public class TaskAdminController {
                             "message":"TODO something is happening"
                           }
                           """)))
-  public ResponseEntity<Object> details(@PathVariable String type, @PathVariable UUID uuid)
+  public ResponseEntity<Object> details(@PathVariable TaskType type, @PathVariable UUID uuid)
       throws ResponseStatusException {
     logger.debug("Getting task details for {}:{}", type, uuid);
 
@@ -272,7 +273,7 @@ public class TaskAdminController {
           @Content(
               mediaType = MediaType.APPLICATION_JSON_VALUE,
               schema = @Schema(example = "{\"message\":\"Task starting accepted\",\"code\":202}")))
-  public ResponseEntity<Object> startTask(@PathVariable String type, @PathVariable UUID uuid)
+  public ResponseEntity<Object> startTask(@PathVariable TaskType type, @PathVariable UUID uuid)
       throws ResponseStatusException {
     logger.debug("Starting task {}:{}", type, uuid);
 
@@ -311,7 +312,7 @@ public class TaskAdminController {
           @Content(
               mediaType = MediaType.APPLICATION_JSON_VALUE,
               schema = @Schema(example = "{\"message\":\"Task stopping accepted\"}")))
-  public ResponseEntity<Object> stopTask(@PathVariable String type, @PathVariable UUID uuid)
+  public ResponseEntity<Object> stopTask(@PathVariable TaskType type, @PathVariable UUID uuid)
       throws ResponseStatusException {
     logger.debug("Stopping task {}:{}", type, uuid);
 
@@ -345,7 +346,7 @@ public class TaskAdminController {
               mediaType = MediaType.APPLICATION_JSON_VALUE,
               schema = @Schema(example = "{\"message\":\"Task not found\"}")))
   @ApiResponse(responseCode = "204", description = "Task is deleted")
-  public ResponseEntity<Object> delete(@PathVariable String type, @PathVariable UUID uuid)
+  public ResponseEntity<Object> delete(@PathVariable TaskType type, @PathVariable UUID uuid)
       throws ResponseStatusException {
 
     try {

--- a/src/main/java/org/tailormap/api/controller/admin/TaskAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/TaskAdminController.java
@@ -6,6 +6,7 @@
 package org.tailormap.api.controller.admin;
 
 import static java.net.HttpURLConnection.HTTP_ACCEPTED;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -25,11 +26,13 @@ import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
+import org.quartz.TriggerKey;
 import org.quartz.TriggerUtils;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.quartz.spi.OperableTrigger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -41,6 +44,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import org.tailormap.api.scheduling.Task;
+import org.tailormap.api.scheduling.TaskManagerService;
 
 /**
  * Admin controller for controlling the task scheduler. Not to be used to create new tasks, adding
@@ -53,14 +58,22 @@ public class TaskAdminController {
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final Scheduler scheduler;
+  private final TaskManagerService taskManagerService;
 
-  public TaskAdminController(Scheduler scheduler) {
+  public TaskAdminController(
+      @Autowired Scheduler scheduler, @Autowired TaskManagerService taskManagerService) {
     this.scheduler = scheduler;
+    this.taskManagerService = taskManagerService;
   }
 
   @Operation(
       summary = "List all tasks, optionally filtered by type",
-      description = "This will return a list of all tasks, optionally filtered by task type")
+      description =
+          """
+          This will return a list of all tasks, optionally filtered by task type.
+          The state of the task is one of the Quartz Trigger states.
+          The state can be one of: NONE, NORMAL, PAUSED, COMPLETE, ERROR, BLOCKED or null in error conditions.
+          """)
   @GetMapping(
       path = "${tailormap-api.admin.base-path}/tasks",
       produces = MediaType.APPLICATION_JSON_VALUE)
@@ -73,34 +86,60 @@ public class TaskAdminController {
               schema =
                   @Schema(
                       example =
-                          "{\"tasks\":[{\"uuid\":\"6308d26e-fe1e-4268-bb28-20db2cd06914\",\"type\":\"poc\"},{\"uuid\":\"d5ce9152-e90e-4b5a-b129-3b2366cabca8\",\"type\":\"poc\"}]}")))
-  public ResponseEntity<?> list(@RequestParam(required = false) String type)
-      throws SchedulerException {
+                          """
+                          {"tasks":[
+                          {"uuid":"6308d26e-fe1e-4268-bb28-20db2cd06914","type":"poc", "state":"NORMAL"},
+                          {"uuid":"d5ce9152-e90e-4b5a-b129-3b2366cabca8","type":"poc", "state": "BLOCKED"},
+                          {"uuid":"d5ce9152-e90e-4b5a-b129-3b2366cabca9","type":"poc", "state": "PAUSED"},
+                          {"uuid":"d5ce9152-e90e-4b5a-b129-3b2366cabca2","type":"poc", "state": "COMPLETE"},
+                          {"uuid":"d5ce9152-e90e-4b5a-b129-3b2366cabca3","type":"poc", "state": "ERROR"}
+                          ]}
+                          """)))
+  public ResponseEntity<Object> list(@RequestParam(required = false) String type)
+      throws ResponseStatusException {
     logger.debug("Listing all tasks (optional type filter: {})", (null == type ? "all" : type));
-    List<ObjectNode> tasks = new ArrayList<>();
+    final List<ObjectNode> tasks = new ArrayList<>();
 
-    GroupMatcher<JobKey> groupMatcher =
+    final GroupMatcher<JobKey> groupMatcher =
         (null == type ? GroupMatcher.anyGroup() : GroupMatcher.groupEquals(type));
-    scheduler.getJobKeys(groupMatcher).stream()
-        .map(
-            jobKey -> {
-              try {
-                return scheduler.getJobDetail(jobKey);
-              } catch (SchedulerException e) {
-                logger.error("Error getting task detail", e);
-                return null;
-              }
-            })
-        .filter(Objects::nonNull)
-        .forEach(
-            jobDetail -> {
-              tasks.add(
-                  new ObjectMapper()
-                      .createObjectNode()
-                      .put("uuid", jobDetail.getKey().getName())
-                      .put("type", jobDetail.getKey().getGroup())
-                      .put("description", jobDetail.getJobDataMap().getString("description")));
-            });
+    try {
+      scheduler.getJobKeys(groupMatcher).stream()
+          .map(
+              jobKey -> {
+                try {
+                  return scheduler.getJobDetail(jobKey);
+                } catch (SchedulerException e) {
+                  logger.error("Error getting task detail", e);
+                  return null;
+                }
+              })
+          .filter(Objects::nonNull)
+          .forEach(
+              jobDetail -> {
+                Trigger.TriggerState state;
+                try {
+                  state =
+                      scheduler.getTriggerState(
+                          TriggerKey.triggerKey(
+                              jobDetail.getKey().getName(), jobDetail.getKey().getGroup()));
+                } catch (SchedulerException e) {
+                  logger.error("Error getting task state", e);
+                  // ignore; to get a null (unknown) state
+                  state = null;
+                }
+                tasks.add(
+                    new ObjectMapper()
+                        .createObjectNode()
+                        .put(Task.UUID_KEY, jobDetail.getKey().getName())
+                        .put(Task.TYPE_KEY, jobDetail.getKey().getGroup())
+                        .put(
+                            Task.DESCRIPTION_KEY,
+                            jobDetail.getJobDataMap().getString(Task.DESCRIPTION_KEY))
+                        .putPOJO(Task.STATE_KEY, state));
+              });
+    } catch (SchedulerException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error getting tasks", e);
+    }
 
     return ResponseEntity.ok(
         new ObjectMapper()
@@ -111,17 +150,20 @@ public class TaskAdminController {
   @Operation(
       summary = "List all details for a given task",
       description =
-          "This will return the details of the task, including the status, progress, result and any message")
+          """
+          This will return the details of the task, including the status, progress,
+          result and any other information.
+          """)
   @GetMapping(
       path = "${tailormap-api.admin.base-path}/tasks/{type}/{uuid}",
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ApiResponse(
       responseCode = "404",
-      description = "Task does not exist",
+      description = "Task not found",
       content =
           @Content(
               mediaType = MediaType.APPLICATION_JSON_VALUE,
-              schema = @Schema(example = "{\"message\":\"Task does not exist\",\"code\":404}")))
+              schema = @Schema(example = "{\"message\":\"Task not found\",\"code\":404}")))
   @ApiResponse(
       responseCode = "200",
       description = "Details of the task",
@@ -142,63 +184,72 @@ public class TaskAdminController {
                               "type":"poc",
                               "description":"This is a poc task"
                             },
-                            "status":"NORMAL",
+                            "state":"NORMAL",
                             "progress":"TODO",
                             "result":"TODO",
                             "message":"TODO something is happening"
                           }
                           """)))
-  public ResponseEntity<?> details(@PathVariable String type, @PathVariable UUID uuid)
-      throws SchedulerException {
+  public ResponseEntity<Object> details(@PathVariable String type, @PathVariable UUID uuid)
+      throws ResponseStatusException {
     logger.debug("Getting task details for {}:{}", type, uuid);
 
-    JobDetail jobDetail = scheduler.getJobDetail(getJobKey(type, uuid));
-    JobDataMap jobDataMap = jobDetail.getJobDataMap();
+    try {
+      JobKey jobKey = taskManagerService.getJobKey(type, uuid);
+      if (null == jobKey) {
+        return handleTaskNotFound();
+      }
 
-    /* there should be only one */
-    Trigger trigger = scheduler.getTriggersOfJob(jobDetail.getKey()).get(0);
-    CronTrigger cron = ((CronTrigger) trigger);
+      JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+      JobDataMap jobDataMap = jobDetail.getJobDataMap();
 
-    final Object[] result = new Object[1];
-    scheduler.getCurrentlyExecutingJobs().stream()
-        .filter(Objects::nonNull)
-        .forEach(
-            jobExecutionContext -> {
-              logger.debug(
-                  "currently executing job {} with trigger {}.",
-                  jobExecutionContext.getJobDetail().getKey(),
-                  jobExecutionContext.getTrigger().getKey());
+      /* there should be only one */
+      Trigger trigger = scheduler.getTriggersOfJob(jobDetail.getKey()).get(0);
+      CronTrigger cron = ((CronTrigger) trigger);
 
-              result[0] = jobExecutionContext.getResult();
-              //
-              // jobDataMap=  jobExecutionContext.getMergedJobDataMap();
-            });
+      final Object[] result = new Object[1];
+      scheduler.getCurrentlyExecutingJobs().stream()
+          .filter(Objects::nonNull)
+          .forEach(
+              jobExecutionContext -> {
+                logger.debug(
+                    "currently executing job {} with trigger {}.",
+                    jobExecutionContext.getJobDetail().getKey(),
+                    jobExecutionContext.getTrigger().getKey());
 
-    return ResponseEntity.ok(
-        new ObjectMapper()
-            .createObjectNode()
-            // immutable uuid, type and description
-            .put("uuid", jobDetail.getKey().getName())
-            .put("type", jobDetail.getKey().getGroup())
-            .put("description", jobDataMap.getString("description"))
-            .put("cronExpression", cron.getCronExpression())
-            // TODO / XXX we could add a human-readable description of the cron expression using eg.
-            //   com.cronutils:cron-utils like:
-            //     CronParser cronParser = new
-            //         CronParser(CronDefinitionBuilder.instanceDefinitionFor(QUARTZ));
-            //     CronDescriptor.instance(locale).describe(cronParser.parse(cronExpression));
-            //   this could also be done front-end using eg. https://www.npmjs.com/package/cronstrue
-            //   which has the advantage of knowing the required locale for the human
-            // .put("cronDescription", cron.getCronExpression())
-            .put("timezone", cron.getTimeZone().getID())
-            .putPOJO("startTime", trigger.getStartTime())
-            .putPOJO("lastTime", trigger.getPreviousFireTime())
-            .putPOJO(
-                "nextFireTimes", TriggerUtils.computeFireTimes((OperableTrigger) cron, null, 5))
-            .putPOJO("status", scheduler.getTriggerState(trigger.getKey()))
-            .putPOJO("progress", result[0])
-            .put("lastResult", jobDataMap.getString("lastResult"))
-            .putPOJO("jobData", jobDataMap));
+                result[0] = jobExecutionContext.getResult();
+              });
+
+      return ResponseEntity.ok(
+          new ObjectMapper()
+              .createObjectNode()
+              // immutable uuid, type and description
+              .put(Task.UUID_KEY, jobDetail.getKey().getName())
+              .put(Task.TYPE_KEY, jobDetail.getKey().getGroup())
+              .put(Task.DESCRIPTION_KEY, jobDataMap.getString(Task.DESCRIPTION_KEY))
+              .put(Task.CRON_EXPRESSION_KEY, cron.getCronExpression())
+              // TODO / XXX we could add a human-readable description of the cron expression using
+              // eg.
+              //   com.cronutils:cron-utils like:
+              //     CronParser cronParser = new
+              //         CronParser(CronDefinitionBuilder.instanceDefinitionFor(QUARTZ));
+              //     CronDescriptor.instance(locale).describe(cronParser.parse(cronExpression));
+              //   this could also be done front-end using eg.
+              // https://www.npmjs.com/package/cronstrue
+              //   which has the advantage of knowing the required locale for the human
+              // .put("cronDescription", cron.getCronExpression())
+              .put("timezone", cron.getTimeZone().getID())
+              .putPOJO("startTime", trigger.getStartTime())
+              .putPOJO("lastTime", trigger.getPreviousFireTime())
+              .putPOJO(
+                  "nextFireTimes", TriggerUtils.computeFireTimes((OperableTrigger) cron, null, 5))
+              .putPOJO(Task.STATE_KEY, scheduler.getTriggerState(trigger.getKey()))
+              .putPOJO("progress", result[0])
+              .put("lastResult", jobDataMap.getString("lastResult"))
+              .putPOJO("jobData", jobDataMap));
+    } catch (SchedulerException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error getting task", e);
+    }
   }
 
   @Operation(
@@ -209,11 +260,11 @@ public class TaskAdminController {
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ApiResponse(
       responseCode = "404",
-      description = "Task does not exist",
+      description = "Task not found",
       content =
           @Content(
               mediaType = MediaType.APPLICATION_JSON_VALUE,
-              schema = @Schema(example = "{\"message\":\"Task does not exist\",\"code\":404}")))
+              schema = @Schema(example = "{\"message\":\"Task not found\",\"code\":404}")))
   @ApiResponse(
       responseCode = "202",
       description = "Task is started",
@@ -221,11 +272,23 @@ public class TaskAdminController {
           @Content(
               mediaType = MediaType.APPLICATION_JSON_VALUE,
               schema = @Schema(example = "{\"message\":\"Task starting accepted\",\"code\":202}")))
-  public ResponseEntity<?> startTask(@PathVariable String type, @PathVariable UUID uuid) {
+  public ResponseEntity<Object> startTask(@PathVariable String type, @PathVariable UUID uuid)
+      throws ResponseStatusException {
     logger.debug("Starting task {}:{}", type, uuid);
 
-    return ResponseEntity.status(HttpStatusCode.valueOf(HTTP_ACCEPTED))
-        .body(new ObjectMapper().createObjectNode().put("message", "TODO: Task starting accepted"));
+    try {
+      JobKey jobKey = taskManagerService.getJobKey(type, uuid);
+      if (null == jobKey) {
+        return handleTaskNotFound();
+      }
+
+      return ResponseEntity.status(HttpStatusCode.valueOf(HTTP_ACCEPTED))
+          .body(
+              new ObjectMapper().createObjectNode().put("message", "TODO: Task starting accepted"));
+
+    } catch (SchedulerException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error getting task", e);
+    }
   }
 
   @Operation(
@@ -236,11 +299,11 @@ public class TaskAdminController {
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ApiResponse(
       responseCode = "404",
-      description = "Task does not exist",
+      description = "Task not found",
       content =
           @Content(
               mediaType = MediaType.APPLICATION_JSON_VALUE,
-              schema = @Schema(example = "{\"message\":\"Task does not exist\"}")))
+              schema = @Schema(example = "{\"message\":\"Task not found\", \"code\":404}")))
   @ApiResponse(
       responseCode = "202",
       description = "Task is stopping",
@@ -248,11 +311,23 @@ public class TaskAdminController {
           @Content(
               mediaType = MediaType.APPLICATION_JSON_VALUE,
               schema = @Schema(example = "{\"message\":\"Task stopping accepted\"}")))
-  public ResponseEntity<?> stopTask(@PathVariable String type, @PathVariable UUID uuid) {
+  public ResponseEntity<Object> stopTask(@PathVariable String type, @PathVariable UUID uuid)
+      throws ResponseStatusException {
     logger.debug("Stopping task {}:{}", type, uuid);
 
-    return ResponseEntity.status(HttpStatusCode.valueOf(HTTP_ACCEPTED))
-        .body(new ObjectMapper().createObjectNode().put("message", "TODO: Task stopping accepted"));
+    try {
+      JobKey jobKey = taskManagerService.getJobKey(type, uuid);
+      if (null == jobKey) {
+        return handleTaskNotFound();
+      }
+
+      return ResponseEntity.status(HttpStatusCode.valueOf(HTTP_ACCEPTED))
+          .body(
+              new ObjectMapper().createObjectNode().put("message", "TODO: Task stopping accepted"));
+
+    } catch (SchedulerException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error getting task", e);
+    }
   }
 
   @Operation(
@@ -264,36 +339,37 @@ public class TaskAdminController {
       produces = MediaType.APPLICATION_JSON_VALUE)
   @ApiResponse(
       responseCode = "404",
-      description = "Task does not exist",
+      description = "Task not found",
       content =
           @Content(
               mediaType = MediaType.APPLICATION_JSON_VALUE,
-              schema = @Schema(example = "{\"message\":\"Task does not exist\"}")))
+              schema = @Schema(example = "{\"message\":\"Task not found\"}")))
   @ApiResponse(responseCode = "204", description = "Task is deleted")
-  public ResponseEntity<?> delete(@PathVariable String type, @PathVariable UUID uuid)
-      throws SchedulerException {
+  public ResponseEntity<Object> delete(@PathVariable String type, @PathVariable UUID uuid)
+      throws ResponseStatusException {
 
-    boolean succes = scheduler.deleteJob(getJobKey(type, uuid));
-    logger.info("Task {}:{} deletion {}", type, uuid, (succes ? "succeeded" : "failed"));
+    try {
+      JobKey jobKey = taskManagerService.getJobKey(type, uuid);
+      if (null == jobKey) {
+        return handleTaskNotFound();
+      }
 
-    return ResponseEntity.noContent().build();
+      boolean succes = scheduler.deleteJob(jobKey);
+      logger.info("Task {}:{} deletion {}", type, uuid, (succes ? "succeeded" : "failed"));
+
+      return ResponseEntity.noContent().build();
+    } catch (SchedulerException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error getting task", e);
+    }
   }
 
-  /**
-   * Get the job key for a given type and uuid.
-   *
-   * @param type the type of the job
-   * @param uuid the uuid of the job
-   * @return the job key
-   * @throws SchedulerException when the scheduler cannot be reached
-   * @throws ResponseStatusException when the job does not exist
-   */
-  private JobKey getJobKey(String type, UUID uuid)
-      throws SchedulerException, ResponseStatusException {
-    logger.debug("Finding job key for task {}:{}", type, uuid);
-    return scheduler.getJobKeys(GroupMatcher.groupEquals(type)).stream()
-        .filter(jobkey -> jobkey.getName().equals(uuid.toString()))
-        .findFirst()
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+  private ResponseEntity<Object> handleTaskNotFound() {
+    return ResponseEntity.status(HttpStatusCode.valueOf(HTTP_NOT_FOUND))
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+            new ObjectMapper()
+                .createObjectNode()
+                .put("message", "Task not found")
+                .put("code", HTTP_NOT_FOUND));
   }
 }

--- a/src/main/java/org/tailormap/api/persistence/SearchIndex.java
+++ b/src/main/java/org/tailormap/api/persistence/SearchIndex.java
@@ -146,8 +146,9 @@ public class SearchIndex implements Serializable {
     return schedule;
   }
 
-  public void setSchedule(@Valid TaskSchedule schedule) {
+  public SearchIndex setSchedule(@Valid TaskSchedule schedule) {
     this.schedule = schedule;
+    return this;
   }
 
   public enum Status {

--- a/src/main/java/org/tailormap/api/persistence/SearchIndex.java
+++ b/src/main/java/org/tailormap/api/persistence/SearchIndex.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.annotations.Type;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.tailormap.api.admin.model.TaskSchedule;
 
 /** SearchIndex is a table that stores the metadata for search indexes for a feature type. */
 @Entity
@@ -58,35 +59,11 @@ public class SearchIndex implements Serializable {
   @JsonProperty("lastIndexed")
   private OffsetDateTime lastIndexed;
 
-  public enum Status {
-    INITIAL("initial"),
-    INDEXING("indexing"),
-    INDEXED("indexed"),
-    ERROR("error");
-    private final String value;
-
-    Status(String value) {
-      this.value = value;
-    }
-
-    public String getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    public static SearchIndex.Status fromValue(String value) {
-      for (SearchIndex.Status status : SearchIndex.Status.values()) {
-        if (status.value.equals(value)) {
-          return status;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '%s'".formatted(value));
-    }
-  }
+  @Valid
+  @JsonProperty("schedule")
+  @Type(value = io.hypersistence.utils.hibernate.type.json.JsonBinaryType.class)
+  @Column(columnDefinition = "jsonb")
+  private TaskSchedule schedule;
 
   @Enumerated(EnumType.STRING)
   @NotNull
@@ -163,5 +140,43 @@ public class SearchIndex implements Serializable {
   public SearchIndex setStatus(Status status) {
     this.status = status;
     return this;
+  }
+
+  public @Valid TaskSchedule getSchedule() {
+    return schedule;
+  }
+
+  public void setSchedule(@Valid TaskSchedule schedule) {
+    this.schedule = schedule;
+  }
+
+  public enum Status {
+    INITIAL("initial"),
+    INDEXING("indexing"),
+    INDEXED("indexed"),
+    ERROR("error");
+    private final String value;
+
+    Status(String value) {
+      this.value = value;
+    }
+
+    public static SearchIndex.Status fromValue(String value) {
+      for (SearchIndex.Status status : SearchIndex.Status.values()) {
+        if (status.value.equals(value)) {
+          return status;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '%s'".formatted(value));
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
   }
 }

--- a/src/main/java/org/tailormap/api/repository/SearchIndexRepository.java
+++ b/src/main/java/org/tailormap/api/repository/SearchIndexRepository.java
@@ -6,6 +6,7 @@
 package org.tailormap.api.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.tailormap.api.persistence.SearchIndex;
@@ -16,4 +17,6 @@ import org.tailormap.api.persistence.SearchIndex;
     itemResourceRel = "search-index")
 public interface SearchIndexRepository extends JpaRepository<SearchIndex, Long> {
   List<SearchIndex> findByFeatureTypeId(Long featureTypeId);
+
+  Optional<SearchIndex> findByName(String name);
 }

--- a/src/main/java/org/tailormap/api/repository/events/SearchIndexEventHandler.java
+++ b/src/main/java/org/tailormap/api/repository/events/SearchIndexEventHandler.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.repository.events;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Map;
+import java.util.UUID;
+import org.quartz.JobDataMap;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.core.annotation.HandleAfterDelete;
+import org.springframework.data.rest.core.annotation.HandleBeforeSave;
+import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
+import org.springframework.stereotype.Component;
+import org.tailormap.api.persistence.SearchIndex;
+import org.tailormap.api.scheduling.IndexTask;
+import org.tailormap.api.scheduling.TMJobDataMap;
+import org.tailormap.api.scheduling.Task;
+import org.tailormap.api.scheduling.TaskManagerService;
+
+/**
+ * Event handler for Solr indexes; when a {@code SearchIndex} is created, updated or deleted a
+ * {@code Task} is associated.
+ */
+@Component
+@RepositoryEventHandler
+public class SearchIndexEventHandler {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final Scheduler scheduler;
+  private final TaskManagerService taskManagerService;
+
+  public SearchIndexEventHandler(
+      @Autowired Scheduler scheduler, @Autowired TaskManagerService taskManagerService) {
+    this.scheduler = scheduler;
+    this.taskManagerService = taskManagerService;
+  }
+
+  /**
+   * Handle after delete. Delete any associated task.
+   *
+   * @param searchIndex the search index that was deleted
+   */
+  @HandleAfterDelete
+  public void afterDeleteSearchIndexEventHandler(SearchIndex searchIndex)
+      throws SchedulerException {
+    if (null != searchIndex.getSchedule()) {
+      JobKey jobKey =
+          taskManagerService.getJobKey(IndexTask.TYPE, searchIndex.getSchedule().getUuid());
+
+      if (null != jobKey && scheduler.checkExists(jobKey)) {
+        logger.info(
+            "Deleting index task {} associated with search index: {}",
+            searchIndex.getSchedule().getUuid(),
+            searchIndex.getName());
+        boolean succes = scheduler.deleteJob(jobKey);
+        logger.info(
+            "Task {}:{} deletion {}",
+            jobKey.getGroup(),
+            jobKey.getName(),
+            (succes ? "succeeded" : "failed"));
+      }
+    }
+  }
+
+  /**
+   * Handle before save. Create or update the associated task.
+   *
+   * @param searchIndex the search index that was saved
+   * @throws SchedulerException if the task could not be created or updated
+   */
+  @HandleBeforeSave
+  public void beforeSaveSearchIndexEventHandler(SearchIndex searchIndex) throws SchedulerException {
+    // TODO we don't handle the case where the schedule is null here; we would need to determine if
+    //   a task exists that was associated with the search index before;
+    //   this case can already be handled requesting a delete of the scheduled task instead
+    if (null != searchIndex.getSchedule()) {
+      if (searchIndex.getSchedule().getUuid() == null) {
+        // no task exists yet, create one
+        logger.info("Creating new task associated with search index: {}", searchIndex.getName());
+        TMJobDataMap jobDataMap =
+            new TMJobDataMap(
+                Map.of(
+                    Task.TYPE_KEY,
+                    IndexTask.TYPE,
+                    Task.DESCRIPTION_KEY,
+                    searchIndex.getSchedule().getDescription(),
+                    IndexTask.INDEX_KEY,
+                    searchIndex.getId().toString()));
+        jobDataMap.setPriority(searchIndex.getSchedule().getPriority());
+        final UUID uuid =
+            taskManagerService.createTask(
+                IndexTask.class, jobDataMap, searchIndex.getSchedule().getCronExpression());
+        searchIndex.getSchedule().setUuid(uuid);
+      } else {
+        // task exists, update it
+        logger.info(
+            "Updating task {} associated with search index: {}",
+            searchIndex.getSchedule().getUuid(),
+            searchIndex.getName());
+
+        JobKey jobKey =
+            taskManagerService.getJobKey(IndexTask.TYPE, searchIndex.getSchedule().getUuid());
+        if (null != jobKey && scheduler.checkExists(jobKey)) {
+          // the only things that may have changed are the cron expression, priority and description
+          JobDataMap jobDataMap = scheduler.getJobDetail(jobKey).getJobDataMap();
+          jobDataMap.put(Task.DESCRIPTION_KEY, searchIndex.getSchedule().getDescription());
+          jobDataMap.put(Task.CRON_EXPRESSION_KEY, searchIndex.getSchedule().getCronExpression());
+          jobDataMap.put(Task.PRIORITY_KEY, searchIndex.getSchedule().getPriority());
+
+          taskManagerService.updateTask(jobKey, new TMJobDataMap(jobDataMap));
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/org/tailormap/api/scheduling/FailingPocTask.java
+++ b/src/main/java/org/tailormap/api/scheduling/FailingPocTask.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.scheduling;
+
+import java.lang.invoke.MethodHandles;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.PersistJobDataAfterExecution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+/** POC task for testing purposes. This task always fails. */
+@DisallowConcurrentExecution
+@PersistJobDataAfterExecution
+public class FailingPocTask extends QuartzJobBean implements Task {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private String description;
+
+  @Override
+  protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+    final JobDetail jobDetail = context.getJobDetail();
+
+    // NOTE: This map is mutable and can be used to store job data.
+    final JobDataMap jobDataMap = jobDetail.getJobDataMap();
+
+    try {
+      // Simulate some work for a random period of time
+      long workingTime = (long) (Math.random() * 10000);
+      logger.debug("Working for {} ms", workingTime);
+      Thread.sleep(workingTime);
+      throw new UnsupportedOperationException("Failing POC task failed.");
+    } catch (Exception e) {
+      logger.error("Failing POC task failed.", e);
+      jobDataMap.put("lastResult", "POC task executed unsuccessfully");
+      context.setResult("POC task executed unsuccessfully");
+      throw new JobExecutionException(e);
+    }
+  }
+
+  // <editor-fold desc="Getters and Setters">
+
+  @Override
+  public TaskType getType() {
+    return TaskType.FAILINGPOC;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public void setDescription(String description) {
+    this.description = description;
+  }
+  // </editor-fold>
+}

--- a/src/main/java/org/tailormap/api/scheduling/IndexTask.java
+++ b/src/main/java/org/tailormap/api/scheduling/IndexTask.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.scheduling;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.time.Instant;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.common.SolrException;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.PersistJobDataAfterExecution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.NonNull;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
+import org.tailormap.api.persistence.SearchIndex;
+import org.tailormap.api.persistence.TMFeatureType;
+import org.tailormap.api.repository.FeatureTypeRepository;
+import org.tailormap.api.repository.SearchIndexRepository;
+import org.tailormap.api.solr.SolrHelper;
+import org.tailormap.api.solr.SolrService;
+
+@DisallowConcurrentExecution
+@PersistJobDataAfterExecution
+public class IndexTask extends QuartzJobBean implements Task {
+  public static final String TYPE = "index";
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final FeatureSourceFactoryHelper featureSourceFactoryHelper;
+  private final SolrService solrService;
+  private final FeatureTypeRepository featureTypeRepository;
+  private final SearchIndexRepository searchIndexRepository;
+
+  private long index;
+
+  public IndexTask(
+      @Autowired SearchIndexRepository searchIndexRepository,
+      @Autowired FeatureTypeRepository featureTypeRepository,
+      @Autowired FeatureSourceFactoryHelper featureSourceFactoryHelper,
+      @Autowired SolrService solrService) {
+
+    this.featureSourceFactoryHelper = featureSourceFactoryHelper;
+    this.solrService = solrService;
+    this.featureTypeRepository = featureTypeRepository;
+    this.searchIndexRepository = searchIndexRepository;
+  }
+
+  @Override
+  protected void executeInternal(@NonNull JobExecutionContext context)
+      throws JobExecutionException {
+
+    final JobDataMap persistedJobData = context.getJobDetail().getJobDataMap();
+    // final long searchIndexId = persistedJobData.getLong("index");
+    logger.debug(
+        "Start Executing IndexTask {} for index {}", context.getJobDetail().getKey(), getIndex());
+
+    SearchIndex searchIndex =
+        searchIndexRepository
+            .findById(getIndex())
+            .orElseThrow(() -> new JobExecutionException("Search index not found"));
+
+    TMFeatureType indexingFT =
+        featureTypeRepository
+            .findById(searchIndex.getFeatureTypeId())
+            .orElseThrow(() -> new JobExecutionException("Feature type not found"));
+
+    try (SolrClient solrClient = solrService.getSolrClientForIndexing();
+        SolrHelper solrHelper = new SolrHelper(solrClient)) {
+
+      searchIndex.setStatus(SearchIndex.Status.INDEXING);
+      searchIndex = searchIndexRepository.save(searchIndex);
+
+      searchIndex =
+          solrHelper.addFeatureTypeIndex(
+              searchIndex, indexingFT, featureSourceFactoryHelper, searchIndexRepository);
+      searchIndex = searchIndex.setStatus(SearchIndex.Status.INDEXED);
+      searchIndexRepository.save(searchIndex);
+      persistedJobData.put(
+          "executions", (1 + (int) context.getMergedJobDataMap().getOrDefault("executions", 0)));
+      persistedJobData.put("lastExecutionFinished", Instant.now());
+      persistedJobData.put("lastResult", "Index task executed successfully");
+      context.setResult("Index task executed successfully");
+    } catch (UnsupportedOperationException | IOException | SolrServerException | SolrException e) {
+      logger.error("Error indexing", e);
+      searchIndex.setStatus(SearchIndex.Status.ERROR);
+      searchIndexRepository.save(searchIndex);
+      throw new JobExecutionException("Error indexing", e);
+    }
+  }
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+
+  public long getIndex() {
+    return index;
+  }
+
+  public void setIndex(long index) {
+    this.index = index;
+  }
+}

--- a/src/main/java/org/tailormap/api/scheduling/IndexTask.java
+++ b/src/main/java/org/tailormap/api/scheduling/IndexTask.java
@@ -33,7 +33,6 @@ import org.tailormap.api.solr.SolrService;
 @DisallowConcurrentExecution
 @PersistJobDataAfterExecution
 public class IndexTask extends QuartzJobBean implements Task {
-  public static final String TYPE = "index";
   public static final String INDEX_KEY = "indexId";
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -99,15 +98,19 @@ public class IndexTask extends QuartzJobBean implements Task {
     } catch (UnsupportedOperationException | IOException | SolrServerException | SolrException e) {
       logger.error("Error indexing", e);
       searchIndex.setStatus(SearchIndex.Status.ERROR).setComment(e.getMessage());
+      persistedJobData.put("lastExecutionFinished", null);
+      persistedJobData.put(
+          "lastResult", "Index task failed with " + e.getMessage() + ". Check logs for details");
       searchIndexRepository.save(searchIndex);
+      context.setResult("Error indexing. Check logs for details.");
       throw new JobExecutionException("Error indexing", e);
     }
   }
 
   // <editor-fold desc="Getters and Setters">
   @Override
-  public String getType() {
-    return TYPE;
+  public TaskType getType() {
+    return TaskType.INDEX;
   }
 
   public long getIndexId() {

--- a/src/main/java/org/tailormap/api/scheduling/PocTask.java
+++ b/src/main/java/org/tailormap/api/scheduling/PocTask.java
@@ -27,6 +27,7 @@ public class PocTask extends QuartzJobBean implements Task {
   public static final String TYPE = "poc";
 
   private String foo;
+  private String description;
 
   @Override
   protected void executeInternal(@NonNull JobExecutionContext context) {
@@ -60,12 +61,16 @@ public class PocTask extends QuartzJobBean implements Task {
       logger.error("Thread interrupted", e);
     }
 
-    jobDataMap.put("executions", (1 + (int) mergedJobDataMap.getOrDefault("executions", 0)));
+    int executions = (1 + (int) mergedJobDataMap.getOrDefault("executions", 0));
+    jobDataMap.put("executions", executions);
     jobDataMap.put("lastExecutionFinished", Instant.now());
     jobDataMap.put("lastResult", "POC task executed successfully");
     context.setResult("POC task executed successfully");
+
+    setFoo("foo executed: " + executions);
   }
 
+  // <editor-fold desc="Getters and Setters">
   public String getFoo() {
     return foo;
   }
@@ -78,4 +83,15 @@ public class PocTask extends QuartzJobBean implements Task {
   public String getType() {
     return TYPE;
   }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public void setDescription(String description) {
+    this.description = description;
+  }
+  // </editor-fold>
 }

--- a/src/main/java/org/tailormap/api/scheduling/PocTask.java
+++ b/src/main/java/org/tailormap/api/scheduling/PocTask.java
@@ -20,9 +20,11 @@ import org.springframework.scheduling.quartz.QuartzJobBean;
 /** POC task for testing purposes. */
 @DisallowConcurrentExecution
 @PersistJobDataAfterExecution
-public class PocTask extends QuartzJobBean {
+public class PocTask extends QuartzJobBean implements Task {
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  public static final String TYPE = "poc";
 
   private String foo;
 
@@ -52,7 +54,7 @@ public class PocTask extends QuartzJobBean {
         logger.debug("Working for {} ms", workingTime);
         Thread.sleep(workingTime);
         logger.debug("POC task is at {}%", i);
-        context.setResult(String.format("POC task is at %d%%", i));
+        context.setResult("POC task is at %d%%".formatted(i));
       }
     } catch (InterruptedException e) {
       logger.error("Thread interrupted", e);
@@ -70,5 +72,10 @@ public class PocTask extends QuartzJobBean {
 
   public void setFoo(String foo) {
     this.foo = foo;
+  }
+
+  @Override
+  public String getType() {
+    return TYPE;
   }
 }

--- a/src/main/java/org/tailormap/api/scheduling/PocTask.java
+++ b/src/main/java/org/tailormap/api/scheduling/PocTask.java
@@ -24,8 +24,6 @@ public class PocTask extends QuartzJobBean implements Task {
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  public static final String TYPE = "poc";
-
   private String foo;
   private String description;
 
@@ -80,8 +78,8 @@ public class PocTask extends QuartzJobBean implements Task {
   }
 
   @Override
-  public String getType() {
-    return TYPE;
+  public TaskType getType() {
+    return TaskType.POC;
   }
 
   @Override

--- a/src/main/java/org/tailormap/api/scheduling/TMJobDataMap.java
+++ b/src/main/java/org/tailormap/api/scheduling/TMJobDataMap.java
@@ -21,10 +21,10 @@ public class TMJobDataMap extends HashMap<String, Object> {
    *     {@code description}
    */
   public TMJobDataMap(Map<String, Object> map) {
-    this((String) map.get("type"), (String) map.get("description"));
+    this((String) map.get(Task.TYPE_KEY), (String) map.get(Task.DESCRIPTION_KEY));
     this.putAll(map);
     // validate the priority
-    this.setPriority((Integer) map.getOrDefault("priority", Trigger.DEFAULT_PRIORITY));
+    this.setPriority((Integer) map.getOrDefault(Task.PRIORITY_KEY, Trigger.DEFAULT_PRIORITY));
   }
 
   /**
@@ -43,11 +43,11 @@ public class TMJobDataMap extends HashMap<String, Object> {
    *
    * @param type the type of the job
    * @param description a description of the job
-   * @param status the status of the job
+   * @param state the state of the job
    */
   public TMJobDataMap(
-      @NotNull String type, @NotNull String description, @NotNull Trigger.TriggerState status) {
-    this(type, description, status, Trigger.DEFAULT_PRIORITY);
+      @NotNull String type, @NotNull String description, @NotNull Trigger.TriggerState state) {
+    this(type, description, state, Trigger.DEFAULT_PRIORITY);
   }
 
   /**
@@ -55,49 +55,50 @@ public class TMJobDataMap extends HashMap<String, Object> {
    *
    * @param type the type of the job
    * @param description a description of the job
-   * @param status the status of the job
+   * @param state the state of the job
    * @param priority the priority of the job, an integer value equal or greater than 0
    */
   public TMJobDataMap(
       @NotNull String type,
       @NotNull String description,
-      @NotNull Trigger.TriggerState status,
+      @NotNull Trigger.TriggerState state,
       int priority) {
     super();
     // Check if the map contains the required parameters
     Assert.notNull(type, "type must not be null");
     Assert.notNull(description, "description must not be null");
-    Assert.notNull(status, "status must not be null");
-    super.put("type", type);
-    super.put("description", description);
-    super.put("status", status);
+    Assert.notNull(state, "state must not be null");
+    super.put(Task.TYPE_KEY, type);
+    super.put(Task.DESCRIPTION_KEY, description);
+    super.put(Task.STATE_KEY, state);
     setPriority(priority);
   }
 
   @NotNull
   public String getType() {
-    return super.get("type").toString();
+    return super.get(Task.TYPE_KEY).toString();
   }
 
   @NotNull
   public String getDescription() {
-    return super.get("description").toString();
+    return super.get(Task.DESCRIPTION_KEY).toString();
   }
 
   @NotNull
-  public Trigger.TriggerState getStatus() {
-    return (Trigger.TriggerState) super.get("status");
+  public Trigger.TriggerState getState() {
+    return (Trigger.TriggerState) super.get(Task.STATE_KEY);
   }
 
-  public void setStatus(Trigger.TriggerState status) {
-    if (null == status) {
-      status = Trigger.TriggerState.NONE;
+  public void setState(Trigger.TriggerState state) {
+    if (null == state) {
+      state = Trigger.TriggerState.NONE;
     }
-    super.put("status", status);
+    super.put(Task.STATE_KEY, state);
   }
 
   /**
-   * Set the priority of the job.
+   * Set the priority of the job. Using this method will ensure that the priority is equal or
+   * greater than 0.
    *
    * @param priority the priority of the job, an integer value equal or greater than 0
    */
@@ -105,10 +106,10 @@ public class TMJobDataMap extends HashMap<String, Object> {
     if (priority < 0) {
       priority = 0;
     }
-    super.put("priority", priority);
+    super.put(Task.PRIORITY_KEY, priority);
   }
 
   public int getPriority() {
-    return (int) super.get("priority");
+    return (int) super.get(Task.PRIORITY_KEY);
   }
 }

--- a/src/main/java/org/tailormap/api/scheduling/TMJobDataMap.java
+++ b/src/main/java/org/tailormap/api/scheduling/TMJobDataMap.java
@@ -21,7 +21,7 @@ public class TMJobDataMap extends HashMap<String, Object> {
    *     {@code description}
    */
   public TMJobDataMap(Map<String, Object> map) {
-    this((String) map.get(Task.TYPE_KEY), (String) map.get(Task.DESCRIPTION_KEY));
+    this(String.valueOf(map.get(Task.TYPE_KEY)), (String) map.get(Task.DESCRIPTION_KEY));
     this.putAll(map);
     // validate the priority
     this.setPriority((Integer) map.getOrDefault(Task.PRIORITY_KEY, Trigger.DEFAULT_PRIORITY));
@@ -66,6 +66,7 @@ public class TMJobDataMap extends HashMap<String, Object> {
     super();
     // Check if the map contains the required parameters
     Assert.notNull(type, "type must not be null");
+    Assert.doesNotContain(type, "null", "type must not be null");
     Assert.notNull(description, "description must not be null");
     Assert.notNull(state, "state must not be null");
     super.put(Task.TYPE_KEY, type);

--- a/src/main/java/org/tailormap/api/scheduling/Task.java
+++ b/src/main/java/org/tailormap/api/scheduling/Task.java
@@ -6,13 +6,35 @@
 package org.tailormap.api.scheduling;
 
 public interface Task {
+
+  String TYPE_KEY = "type";
+  String DESCRIPTION_KEY = "description";
+  String UUID_KEY = "uuid";
+  String CRON_EXPRESSION_KEY = "cronExpression";
+  String PRIORITY_KEY = "priority";
+  String STATE_KEY = "state";
+
   /**
    * Get the type of the task. Implement this method to return a public static final String that is
-   * a key for the type of task.
+   * a key for the type of task. This must be a read-only property
    *
    * @see org.tailormap.api.scheduling.PocTask#TYPE
    * @see org.tailormap.api.scheduling.IndexTask#TYPE
-   * @return the type
+   * @return the type of task
    */
   String getType();
+
+  /**
+   * Get the description of the task.
+   *
+   * @return the description
+   */
+  String getDescription();
+
+  /**
+   * Set the description of the task.
+   *
+   * @param description the description
+   */
+  void setDescription(String description);
 }

--- a/src/main/java/org/tailormap/api/scheduling/Task.java
+++ b/src/main/java/org/tailormap/api/scheduling/Task.java
@@ -15,14 +15,12 @@ public interface Task {
   String STATE_KEY = "state";
 
   /**
-   * Get the type of the task. Implement this method to return a public static final String that is
-   * a key for the type of task. This must be a read-only property
+   * Get the type of the task. Implement this method to return the key for the type of task. This
+   * must be a read-only property.
    *
-   * @see org.tailormap.api.scheduling.PocTask#TYPE
-   * @see org.tailormap.api.scheduling.IndexTask#TYPE
    * @return the type of task
    */
-  String getType();
+  TaskType getType();
 
   /**
    * Get the description of the task.

--- a/src/main/java/org/tailormap/api/scheduling/Task.java
+++ b/src/main/java/org/tailormap/api/scheduling/Task.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.scheduling;
+
+public interface Task {
+  /**
+   * Get the type of the task. Implement this method to return a public static final String that is
+   * a key for the type of task.
+   *
+   * @see org.tailormap.api.scheduling.PocTask#TYPE
+   * @see org.tailormap.api.scheduling.IndexTask#TYPE
+   * @return the type
+   */
+  String getType();
+}

--- a/src/main/java/org/tailormap/api/scheduling/TaskCreator.java
+++ b/src/main/java/org/tailormap/api/scheduling/TaskCreator.java
@@ -46,7 +46,7 @@ public class TaskCreator {
    * @return the task name, a UUID
    * @throws SchedulerException if the job could not be scheduled
    */
-  public String createTask(
+  public UUID createTask(
       Class<? extends QuartzJobBean> job, TMJobDataMap jobData, String cronExpression)
       throws SchedulerException {
 
@@ -62,7 +62,7 @@ public class TaskCreator {
     Trigger trigger =
         TriggerBuilder.newTrigger()
             .withIdentity(jobDetail.getKey().getName(), jobDetail.getKey().getGroup())
-            .startAt(DateBuilder.futureDate(30, DateBuilder.IntervalUnit.SECOND))
+            .startAt(DateBuilder.futureDate(90, DateBuilder.IntervalUnit.SECOND))
             .withPriority(jobData.getPriority())
             .usingJobData(SENTRY_SLUG_KEY, "monitor_slug_cron_trigger_" + jobData.get("type"))
             .withSchedule(
@@ -80,6 +80,6 @@ public class TaskCreator {
       return null;
     }
 
-    return jobDetail.getKey().getName();
+    return UUID.fromString(jobDetail.getKey().getName());
   }
 }

--- a/src/main/java/org/tailormap/api/scheduling/TaskManagerService.java
+++ b/src/main/java/org/tailormap/api/scheduling/TaskManagerService.java
@@ -133,9 +133,9 @@ public class TaskManagerService {
    * @throws SchedulerException when the scheduler cannot be reached
    */
   @Nullable
-  public JobKey getJobKey(String jobType, UUID uuid) throws SchedulerException {
+  public JobKey getJobKey(TaskType jobType, UUID uuid) throws SchedulerException {
     logger.debug("Finding job key for task {}:{}", jobType, uuid);
-    return scheduler.getJobKeys(GroupMatcher.groupEquals(jobType)).stream()
+    return scheduler.getJobKeys(GroupMatcher.groupEquals(jobType.getValue())).stream()
         .filter(jobkey -> jobkey.getName().equals(uuid.toString()))
         .findFirst()
         .orElse(null);

--- a/src/main/java/org/tailormap/api/scheduling/TaskType.java
+++ b/src/main/java/org/tailormap/api/scheduling/TaskType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.scheduling;
+
+public enum TaskType {
+  POC("poc"),
+  FAILINGPOC("failingpoc"),
+  INDEX("index");
+
+  private final String value;
+
+  TaskType(String value) {
+    this.value = value;
+  }
+
+  public static TaskType fromValue(String value) {
+    for (TaskType type : TaskType.values()) {
+      if (type.value.equals(value)) {
+        return type;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '%s'".formatted(value));
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+}

--- a/src/main/resources/db/migration/V11__add_solr_index_schedule_column.sql
+++ b/src/main/resources/db/migration/V11__add_solr_index_schedule_column.sql
@@ -1,0 +1,2 @@
+alter table if exists search_index
+    add column schedule jsonb default null;

--- a/src/main/resources/openapi/admin-schemas.yaml
+++ b/src/main/resources/openapi/admin-schemas.yaml
@@ -56,3 +56,7 @@ components:
           description: 'Cron expression for the task'
           type: string
           nullable: false
+        priority:
+          description: 'Priority of the task'
+          type: integer
+          nullable: true

--- a/src/main/resources/openapi/admin-schemas.yaml
+++ b/src/main/resources/openapi/admin-schemas.yaml
@@ -22,7 +22,7 @@ components:
         eventType:
           type: string
           description: 'Type of event'
-          enum: ['keep-alive', 'entity-created', 'entity-deleted', 'entity-updated']
+          enum: [ 'keep-alive', 'entity-created', 'entity-deleted', 'entity-updated' ]
         details:
           type: object
 
@@ -36,3 +36,23 @@ components:
         object:
           description: 'The entity in JSON, only included in created and updated events.'
           type: object
+
+    TaskSchedule:
+      type: object
+      required:
+        - cronExpression
+      properties:
+        uuid:
+          description: 'UUID of the task; this is the unique identifier of the task'
+          type: string
+          format: uuid
+          readOnly: true
+          nullable: true
+        description:
+          description: 'Human-readable description of the task.'
+          type: string
+          nullable: true
+        cronExpression:
+          description: 'Cron expression for the task'
+          type: string
+          nullable: false

--- a/src/test/java/org/tailormap/api/controller/admin/TaskAdminControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/admin/TaskAdminControllerIntegrationTest.java
@@ -62,7 +62,7 @@ class TaskAdminControllerIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.tasks").isArray())
-            .andExpect(jsonPath("$.tasks.length()").value(2))
+            .andExpect(jsonPath("$.tasks.length()").value(3))
             .andExpect(jsonPath("$.tasks[0].type").value(TEST_TASK_TYPE))
             .andExpect(jsonPath("$.tasks[1].type").value(TEST_TASK_TYPE))
             .andReturn();
@@ -128,11 +128,14 @@ class TaskAdminControllerIntegrationTest {
   void detailsOfTask() throws Exception {
     MvcResult result =
         mockMvc
-            .perform(get(adminBasePath + "/tasks").accept(MediaType.APPLICATION_JSON))
+            .perform(
+                get(adminBasePath + "/tasks")
+                    .queryParam("type", TEST_TASK_TYPE)
+                    .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.tasks").isArray())
-            .andExpect(jsonPath("$.tasks.length()").value(2))
+            .andExpect(jsonPath("$.tasks.length()").value(3))
             .andReturn();
 
     final String detailsUUID =

--- a/src/test/java/org/tailormap/api/scheduling/TMJobDataMapTest.java
+++ b/src/test/java/org/tailormap/api/scheduling/TMJobDataMapTest.java
@@ -17,15 +17,17 @@ class TMJobDataMapTest {
   /** Test the creation using a map with missing required parameters. */
   @Test
   void testInvalidMap() {
-    assertThrows(IllegalArgumentException.class, () -> new TMJobDataMap(Map.of("type", "test")));
+    assertThrows(
+        IllegalArgumentException.class, () -> new TMJobDataMap(Map.of(Task.TYPE_KEY, "test")));
   }
 
   /** Test the creation using a map with all required parameters. */
   @Test
   void testMap() {
-    TMJobDataMap jobDataMap = new TMJobDataMap(Map.of("type", "test", "description", "test"));
+    TMJobDataMap jobDataMap =
+        new TMJobDataMap(Map.of(Task.TYPE_KEY, "test", Task.DESCRIPTION_KEY, "test"));
     assertNotNull(jobDataMap);
-    assertEquals("NONE", jobDataMap.getStatus().name());
+    assertEquals("NONE", jobDataMap.getState().name());
     assertEquals(5, jobDataMap.getPriority());
   }
 
@@ -33,9 +35,10 @@ class TMJobDataMapTest {
   @Test
   void testMapWithPriority() {
     TMJobDataMap jobDataMap =
-        new TMJobDataMap(Map.of("type", "test", "description", "test", "priority", -1));
+        new TMJobDataMap(
+            Map.of(Task.TYPE_KEY, "test", Task.DESCRIPTION_KEY, "test", Task.PRIORITY_KEY, -1));
     assertNotNull(jobDataMap);
-    assertEquals("NONE", jobDataMap.getStatus().name());
+    assertEquals("NONE", jobDataMap.getState().name());
     assertEquals(0, jobDataMap.getPriority());
   }
 }


### PR DESCRIPTION
[![HTM-1254](https://badgen.net/badge/JIRA/HTM-1254/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1254) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- [x] [HTM-1255](https://b3partners.atlassian.net/browse/HTM-1255): update persistence model to support scheduling Solr indexing, see also https://github.com/Tailormap/tailormap-viewer/pull/722
- [x] [HTM-1256](https://b3partners.atlassian.net/browse/HTM-1256): create a task to update Solr indexes
- [x] [HTM-1257](https://b3partners.atlassian.net/browse/HTM-1257): Create SearchIndex EventListener in persistence to create/update/delete Solr indexing tasks
- [x] Update populated testdata
  - scheduled 1 indexing task
- [ ] ~~cleanup PocTask?~~ it is useful for testing the framework, created a ticket to do that later



[HTM-1254]: https://b3partners.atlassian.net/browse/HTM-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-1255]: https://b3partners.atlassian.net/browse/HTM-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-1256]: https://b3partners.atlassian.net/browse/HTM-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-1257]: https://b3partners.atlassian.net/browse/HTM-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ