### PR TITLE
HTM-1259: Dependency updates: flyway, micrometer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <commons-lang3.version>3.17.0</commons-lang3.version>
-        <flyway.version>10.18.2</flyway.version>
+        <flyway.version>10.19.0</flyway.version>
         <hibernate.version>6.5.3.Final</hibernate.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.2</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ SPDX-License-Identifier: MIT
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <flyway.version>10.19.0</flyway.version>
         <hibernate.version>6.5.3.Final</hibernate.version>
-        <jackson-bom.version>2.17.2</jackson-bom.version>
+        <jackson-bom.version>2.18.0</jackson-bom.version>
         <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <!--        <logback.version>1.5.7</logback.version>-->
         <micrometer.version>1.13.6</micrometer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ SPDX-License-Identifier: MIT
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <flyway.version>10.19.0</flyway.version>
         <hibernate.version>6.5.3.Final</hibernate.version>
-        <jackson-bom.version>2.18.0</jackson-bom.version>
+        <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <!--        <logback.version>1.5.7</logback.version>-->
         <micrometer.version>1.13.6</micrometer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <!--        <logback.version>1.5.7</logback.version>-->
-        <micrometer.version>1.13.4</micrometer.version>
+        <micrometer.version>1.13.6</micrometer.version>
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
         <oracle-database.version>23.5.0.24.07</oracle-database.version>


### PR DESCRIPTION
[![HTM-1259](https://badgen.net/badge/JIRA/HTM-1259/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1259) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Bump flyway.version from 10.18.2 to 10.19.0
- Bump micrometer.version from 1.13.4 to 1.13.6
- ~Bump jackson-bom.version from 2.17.2 to 2.18.0~

[HTM-1259]: https://b3partners.atlassian.net/browse/HTM-1259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ