### PR TITLE
HTM-1253: fix java.lang.IllegalStateException: JobStore is shutdown - aborting retry

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,6 +83,7 @@ spring.quartz.jdbc.initialize-schema=never
 spring.quartz.properties.org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
 spring.quartz.properties.org.quartz.threadPool.threadCount=3
 spring.quartz.properties.org.quartz.scheduler.skipUpdateCheck=true
+spring.quartz.overwrite-existing-jobs=true
 
 # Actuator
 


### PR DESCRIPTION
[![HTM-1253](https://badgen.net/badge/JIRA/HTM-1253/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1253) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

this may or may not help, see eg. https://stackoverflow.com/questions/22754318/quartz-job-retrigerring-after-server-shutdown 



[HTM-1253]: https://b3partners.atlassian.net/browse/HTM-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ