### PR TITLE
HTM-1251: Upgrade Spring Boot from 3.3.4 to 3.3.5, rely on the `spring-security.version` provided by Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <commons-lang3.version>3.17.0</commons-lang3.version>
-        <flyway.version>10.19.0</flyway.version>
+        <flyway.version>10.20.1</flyway.version>
         <hibernate.version>6.5.3.Final</hibernate.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.3</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,8 @@ SPDX-License-Identifier: MIT
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
         <oracle-database.version>23.5.0.24.07</oracle-database.version>
         <postgresql.version>42.7.4</postgresql.version>
-        <spring-data-bom.version>2024.0.5</spring-data-bom.version>
-        <spring-hateoas.version>2.3.3</spring-hateoas.version>
+        <!-- <spring-data-bom.version>2024.0.5</spring-data-bom.version> -->
+        <!-- <spring-hateoas.version>2.3.3</spring-hateoas.version> -->
         <!-- <spring-security.version>6.3.4</spring-security.version> -->
         <webjars-locator-core.version>0.59</webjars-locator-core.version>
         <xmlunit2.version>2.10.0</xmlunit2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.3.5</version>
     </parent>
     <groupId>org.tailormap</groupId>
     <artifactId>tailormap-api</artifactId>
@@ -123,7 +123,6 @@ SPDX-License-Identifier: MIT
         <hibernate.version>6.5.3.Final</hibernate.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.3</junit-jupiter.version>
-        <!--        <logback.version>1.5.7</logback.version>-->
         <micrometer.version>1.13.6</micrometer.version>
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
@@ -131,7 +130,7 @@ SPDX-License-Identifier: MIT
         <postgresql.version>42.7.4</postgresql.version>
         <spring-data-bom.version>2024.0.5</spring-data-bom.version>
         <spring-hateoas.version>2.3.3</spring-hateoas.version>
-        <spring-security.version>6.3.3</spring-security.version>
+        <!-- <spring-security.version>6.3.4</spring-security.version> -->
         <webjars-locator-core.version>0.59</webjars-locator-core.version>
         <xmlunit2.version>2.10.0</xmlunit2.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>


### PR DESCRIPTION
- [HTM-1251](https://b3partners.atlassian.net/browse/HTM-1251): Upgrade Spring Boot from 3.3.4 to 3.3.5
- Rely on the `spring-security.version` provided by Spring Boot
- Rely on Spring Boot provided versions of `spring-data-bom` and `spring-hateoas`
- [HTM-1289](https://b3partners.atlassian.net/browse/HTM-1289): Bump flyway.version from 10.19.0 to 10.20.1

this should resolve:
- https://github.com/Tailormap/tailormap-api/security/code-scanning/364
- https://github.com/Tailormap/tailormap-api/security/dependabot/7

[HTM-1251]: https://b3partners.atlassian.net/browse/HTM-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HTM-1289]: https://b3partners.atlassian.net/browse/HTM-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ