### PR TITLE
⛓️‍💥 HTM-1266: explicitly create the INDEX_DISPLAY_FIELD and INDEX_SEARCH_FIELD to make sure these are of the required type ⛓️‍💥

### DIFF
--- a/src/main/java/org/tailormap/api/solr/SolrHelper.java
+++ b/src/main/java/org/tailormap/api/solr/SolrHelper.java
@@ -339,7 +339,7 @@ public class SolrHelper implements AutoCloseable, Constants {
     }
 
     logger.info("Creating Solr field type {}", SEARCH_LAYER);
-    SchemaRequest.AddField schemaRequest =
+    SchemaRequest.AddField searchLayerSchemaRequest =
         new SchemaRequest.AddField(
             Map.of(
                 "name", SEARCH_LAYER,
@@ -349,7 +349,7 @@ public class SolrHelper implements AutoCloseable, Constants {
                 "multiValued", false,
                 "required", true,
                 "uninvertible", false));
-    schemaRequest.process(solrClient);
+    searchLayerSchemaRequest.process(solrClient);
 
     logger.info("Creating Solr field type {}", INDEX_GEOM_FIELD);
     // TODO https://b3partners.atlassian.net/browse/HTM-1091
@@ -364,6 +364,32 @@ public class SolrHelper implements AutoCloseable, Constants {
                 "stored", true,
                 "multiValued", false));
     schemaRequestGeom.process(solrClient);
+
+    logger.info("Creating Solr field type {}", INDEX_DISPLAY_FIELD);
+    SchemaRequest.AddField displayFieldSchemaRequest =
+        new SchemaRequest.AddField(
+            Map.of(
+                "name", INDEX_DISPLAY_FIELD,
+                "type", "text_general",
+                "indexed", false,
+                "stored", true,
+                "multiValued", true,
+                "required", true,
+                "uninvertible", false));
+    displayFieldSchemaRequest.process(solrClient);
+
+    logger.info("Creating Solr field type {}", INDEX_SEARCH_FIELD);
+    SchemaRequest.AddField indexFieldSchemaRequest =
+        new SchemaRequest.AddField(
+            Map.of(
+                "name", INDEX_SEARCH_FIELD,
+                "type", "text_general",
+                "indexed", true,
+                "stored", true,
+                "multiValued", true,
+                "required", true,
+                "uninvertible", false));
+    indexFieldSchemaRequest.process(solrClient);
   }
 
   /**


### PR DESCRIPTION
[![HTM-1266](https://badgen.net/badge/JIRA/HTM-1266/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1266) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**⛓️‍💥 Note: when upgrading you may need to drop the Solr core or at least the schema so full-text indexes can be recreated with the correct type** 
It is not sufficient to delete the indexes, because that will not create a new schema in the `tailormap` Solr core.

[HTM-1266]: https://b3partners.atlassian.net/browse/HTM-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ