### PR TITLE
HTM-1286: Fix code scanning alert no. 352: Server-side request forgery

### DIFF
--- a/src/main/java/org/tailormap/api/controller/LayerExportController.java
+++ b/src/main/java/org/tailormap/api/controller/LayerExportController.java
@@ -27,6 +27,7 @@ import org.geotools.data.wfs.WFSDataStore;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -62,6 +63,9 @@ import org.tailormap.api.viewer.model.LayerExportCapabilities;
 public class LayerExportController {
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Value("#{'${tailormap-api.export.allowed-outputformats}'.split(',')}")
+  private List<String> allowedOutputFormats;
 
   private final FeatureSourceRepository featureSourceRepository;
 
@@ -127,9 +131,6 @@ public class LayerExportController {
       @RequestParam(required = false) String sortOrder,
       @RequestParam(required = false) String crs,
       HttpServletRequest request) {
-
-    // Define allowed output formats
-    List<String> allowedOutputFormats = List.of("application/json", "text/xml", "application/gml+xml");
 
     // Validate outputFormat
     if (!allowedOutputFormats.contains(outputFormat)) {

--- a/src/main/java/org/tailormap/api/controller/LayerExportController.java
+++ b/src/main/java/org/tailormap/api/controller/LayerExportController.java
@@ -128,6 +128,15 @@ public class LayerExportController {
       @RequestParam(required = false) String crs,
       HttpServletRequest request) {
 
+    // Define allowed output formats
+    List<String> allowedOutputFormats = List.of("application/json", "text/xml", "application/gml+xml");
+
+    // Validate outputFormat
+    if (!allowedOutputFormats.contains(outputFormat)) {
+      logger.warn("Invalid output format requested: {}", outputFormat);
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid output format");
+    }
+
     TMFeatureType tmft = service.findFeatureTypeForLayer(layer, featureSourceRepository);
     AppLayerSettings appLayerSettings = application.getAppLayerSettings(appTreeLayerNode);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,9 @@ tailormap-api.features.wfs_count_exact=false
 # maximum number of items to return in a single (WFS/JDBC) feature info request
 tailormap-api.feature.info.maxitems=30
 
+# Should match the list in tailormap-viewer class AttributeListExportService
+tailormap-api.export.allowed-outputformats=csv,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,excel2007,application/vnd.shp,application/x-zipped-shp,SHAPE-ZIP,application/geopackage+sqlite3,application/x-gpkg,geopackage,geopkg,gpkg,application/geo+json,application/geojson,application/json,json,DXF-ZIP
+
 # whether the API should use GeoTools "Unique Collection" (use DISTINCT in SQL statements) or just
 # retrieve all values when calculating the unique values for a property.
 # There might be a performance difference between the two, depending on the data

--- a/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
@@ -109,7 +109,7 @@ class LayerExportControllerIntegrationTest {
             get(url)
                 .with(setServletPath(url))
                 .accept(MediaType.APPLICATION_JSON)
-                .param("outputFormat", "application/json")
+                .param("outputFormat", MediaType.APPLICATION_JSON_VALUE)
                 .param("attributes", "geom,naam,code"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -159,7 +159,7 @@ class LayerExportControllerIntegrationTest {
             get(url)
                 .accept(MediaType.APPLICATION_JSON)
                 .with(setServletPath(url))
-                .param("outputFormat", "application/json")
+                .param("outputFormat", MediaType.APPLICATION_JSON_VALUE)
                 .param("filter", "(BRONHOUDER IN ('G1904','L0002','L0004'))")
                 .param("sortBy", "CLASS")
                 .param("sortOrder", "asc"))
@@ -176,7 +176,7 @@ class LayerExportControllerIntegrationTest {
             get(url)
                 .accept(MediaType.APPLICATION_JSON)
                 .with(setServletPath(url))
-                .param("outputFormat", "application/json")
+                .param("outputFormat", MediaType.APPLICATION_JSON_VALUE)
                 .param("filter", "(BRONHOUDER IN ('G1904','L0002','L0004'))")
                 .param("sortBy", "CLASS")
                 .param("sortOrder", "desc"))
@@ -197,7 +197,7 @@ class LayerExportControllerIntegrationTest {
             get(url)
                 .accept(MediaType.APPLICATION_JSON)
                 .with(setServletPath(url))
-                .param("outputFormat", "application/json")
+                .param("outputFormat", MediaType.APPLICATION_JSON_VALUE)
                 // terminationdate,geom_kruinlijn are hidden attributes
                 .param(
                     "attributes", "identificatie,bronhouder,class,terminationdate,geom_kruinlijn"))
@@ -216,7 +216,7 @@ class LayerExportControllerIntegrationTest {
             get(url)
                 .accept(MediaType.APPLICATION_JSON)
                 .with(setServletPath(url))
-                .param("outputFormat", "application/json")
+                .param("outputFormat", MediaType.APPLICATION_JSON_VALUE)
                 .param("filter", "(bronhouder ILIKE 'L0001')"))
         .andDo(MockMvcResultHandlers.print())
         .andExpect(status().isOk())
@@ -237,7 +237,19 @@ class LayerExportControllerIntegrationTest {
             get(testUrl)
                 .accept(MediaType.APPLICATION_JSON)
                 .with(setServletPath(testUrl))
-                .param("outputFormat", "application/json"))
+                .param("outputFormat", MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void testInvalidOutputFormatNotAccepted() throws Exception {
+    final String testUrl = apiBasePath + layerBegroeidTerreindeelPostgis + "/export/download";
+    mockMvc
+        .perform(
+            get(testUrl)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(setServletPath(testUrl))
+                .param("outputFormat", "Invalid value!"))
+        .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,6 +2,7 @@ tailormap-api.base-path=/api
 tailormap-api.admin.base-path=/api/admin
 management.endpoints.web.base-path=/api/actuator
 tailormap-api.new-admin-username=tm-admin
+tailormap-api.export.allowed-outputformats=application/geopackage+sqlite3,application/json
 tailormap-api.timeout=5000
 tailormap-api.management.hashed-password=#{null}
 spring.profiles.active=test


### PR DESCRIPTION
[![HTM-1286](https://badgen.net/badge/JIRA/HTM-1286/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1286) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes [https://github.com/Tailormap/tailormap-api/security/code-scanning/352](https://github.com/Tailormap/tailormap-api/security/code-scanning/352)

To fix the SSRF vulnerability, we need to validate the user-provided input (`outputFormat`) against a list of allowed values. This ensures that only legitimate and expected values are used to construct the WFS request URI.

1. Define a list of allowed `outputFormat` values.
2. Validate the `outputFormat` parameter against this list before using it to construct the `wfsGetFeature` URI.
3. If the `outputFormat` is not in the allowed list, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

[HTM-1286]: https://b3partners.atlassian.net/browse/HTM-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ