### PR TITLE
HTM-1285: Fix code scanning alert no. 351: Server-side request forgery

### DIFF
--- a/src/main/java/org/tailormap/api/controller/GeoServiceProxyController.java
+++ b/src/main/java/org/tailormap/api/controller/GeoServiceProxyController.java
@@ -164,6 +164,10 @@ public class GeoServiceProxyController {
   private URI buildWMSUrl(GeoService service, HttpServletRequest request) {
     final UriComponentsBuilder originalServiceUrl =
         UriComponentsBuilder.fromHttpUrl(service.getUrl());
+    // Validate the service URL against allowed domains
+    if (!isValidDomain(service.getUrl())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid service URL");
+    }
     // request.getParameterMap() includes parameters from an application/x-www-form-urlencoded POST
     // body
     final MultiValueMap<String, String> requestParams =
@@ -262,6 +266,21 @@ public class GeoServiceProxyController {
       return ResponseEntity.status(response.statusCode()).headers(headers).body(body);
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body("Bad Gateway");
+    }
+  }
+
+  private static final List<String> ALLOWED_DOMAINS = List.of(
+      "example.com",
+      "another-example.com"
+  );
+
+  private boolean isValidDomain(String url) {
+    try {
+      URI uri = new URI(url);
+      String host = uri.getHost();
+      return ALLOWED_DOMAINS.stream().anyMatch(host::endsWith);
+    } catch (Exception e) {
+      return false;
     }
   }
 }


### PR DESCRIPTION
[![HTM-1285](https://badgen.net/badge/JIRA/HTM-1285/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1285) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes [https://github.com/Tailormap/tailormap-api/security/code-scanning/351](https://github.com/Tailormap/tailormap-api/security/code-scanning/351)

To fix the SSRF vulnerability, we need to validate the user-provided URL against a whitelist of allowed URLs or ensure that the constructed URL is limited to a particular host or more restrictive URL prefix. This can be achieved by adding a validation step in the `buildWMSUrl` method to check if the URL belongs to an allowed set of domains.

1. Create a list of allowed domains.
2. Validate the constructed URL against this list.
3. If the URL is not valid, throw an exception or return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

[HTM-1285]: https://b3partners.atlassian.net/browse/HTM-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ