### PR TITLE
Bump quartz.version from 2.4.0 to 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ SPDX-License-Identifier: MIT
         <!-- <spring-data-bom.version>2024.0.5</spring-data-bom.version> -->
         <!-- <spring-hateoas.version>2.3.3</spring-hateoas.version> -->
         <!-- <spring-security.version>6.3.4</spring-security.version> -->
-        <quartz.version>2.4.0</quartz.version>
+        <quartz.version>2.5.0</quartz.version>
         <webjars-locator-core.version>0.59</webjars-locator-core.version>
         <xmlunit2.version>2.10.0</xmlunit2.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>


### PR DESCRIPTION
this uses the Jakarta namespace, which is the most notable change compared to 2.4.0 (see https://github.com/Tailormap/tailormap-api/pull/1034)

see: https://github.com/quartz-scheduler/quartz/releases/tag/v2.5.0