### PR TITLE
Allow schedule to have `null` priority when updating a search index

### DIFF
--- a/src/main/java/org/tailormap/api/repository/events/SearchIndexEventHandler.java
+++ b/src/main/java/org/tailormap/api/repository/events/SearchIndexEventHandler.java
@@ -119,7 +119,10 @@ public class SearchIndexEventHandler {
           JobDataMap jobDataMap = scheduler.getJobDetail(jobKey).getJobDataMap();
           jobDataMap.put(Task.DESCRIPTION_KEY, searchIndex.getSchedule().getDescription());
           jobDataMap.put(Task.CRON_EXPRESSION_KEY, searchIndex.getSchedule().getCronExpression());
-          jobDataMap.put(Task.PRIORITY_KEY, searchIndex.getSchedule().getPriority());
+          if (null != searchIndex.getSchedule().getPriority()
+              && searchIndex.getSchedule().getPriority() > 0) {
+            jobDataMap.put(Task.PRIORITY_KEY, searchIndex.getSchedule().getPriority());
+          }
 
           taskManagerService.updateTask(jobKey, new TMJobDataMap(jobDataMap));
         }

--- a/src/main/java/org/tailormap/api/scheduling/TMJobDataMap.java
+++ b/src/main/java/org/tailormap/api/scheduling/TMJobDataMap.java
@@ -24,7 +24,11 @@ public class TMJobDataMap extends HashMap<String, Object> {
     this(String.valueOf(map.get(Task.TYPE_KEY)), (String) map.get(Task.DESCRIPTION_KEY));
     this.putAll(map);
     // validate the priority
-    this.setPriority((Integer) map.getOrDefault(Task.PRIORITY_KEY, Trigger.DEFAULT_PRIORITY));
+    if (map.containsKey(Task.PRIORITY_KEY)) {
+      this.setPriority((Integer) map.getOrDefault(Task.PRIORITY_KEY, Trigger.DEFAULT_PRIORITY));
+    } else {
+      this.setPriority(Trigger.DEFAULT_PRIORITY);
+    }
   }
 
   /**

--- a/src/main/java/org/tailormap/api/scheduling/TaskManagerService.java
+++ b/src/main/java/org/tailormap/api/scheduling/TaskManagerService.java
@@ -113,7 +113,7 @@ public class TaskManagerService {
                 .withPriority(jobDataMap.getInt(Task.PRIORITY_KEY))
                 .usingJobData(
                     SENTRY_SLUG_KEY,
-                    "monitor_slug_cron_trigger_" + jobDataMap.getString(Task.TYPE_KEY))
+                    "monitor_slug_cron_trigger_" + jobDataMap.get(Task.TYPE_KEY).toString())
                 .withSchedule(
                     CronScheduleBuilder.cronSchedule(jobDataMap.getString(Task.CRON_EXPRESSION_KEY))
                         .withMisfireHandlingInstructionFireAndProceed())


### PR DESCRIPTION
* When a search index is updated the schedule.priority attribute can be null. This is now checked, and if the value is null, the default value is used.
* The type attribute of a task is converted to a string when updating a task in the TaskManagerService.