### PR TITLE
⛓️‍💥 HTM-1332: fix Solr indexing timeouts ⛓️‍💥

### DIFF
--- a/build/ci/docker-compose.yml
+++ b/build/ci/docker-compose.yml
@@ -110,6 +110,8 @@ services:
     image: ghcr.io/tailormap/solr:9.7.0
     environment:
       TZ: Europe/Amsterdam
+      SOLR_OPTS: '$SOLR_OPTS -Dsolr.environment=dev,label=Tailormap+Development,color=#6236FF'
+      SOLR_DELETE_UNKNOWN_CORES: true
     volumes:
       - solr-data:/var/solr
     ports:

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,10 @@ SPDX-License-Identifier: MIT
                     <groupId>org.apache.solr</groupId>
                     <artifactId>solr-solrj-zookeeper</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.solr</groupId>
+                    <artifactId>solr-solrj-streaming</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
@@ -131,6 +131,12 @@ public class PopulateTestData {
   @Value("${MAP5_URL:#{null}}")
   private String map5url;
 
+  @Value("${tailormap-api.solr-batch-size:1000}")
+  private int solrBatchSize;
+
+  @Value("${tailormap-api.solr-geometry-validation-rule:repairBuffer0}")
+  private String solrGeometryValidationRule;
+
   public PopulateTestData(
       ApplicationContext appContext,
       UserRepository userRepository,
@@ -1441,7 +1447,9 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
           "http://" + (connectToSpatialDbsAtLocalhost ? "127.0.0.1" : "solr") + ":8983/solr/";
       this.solrService.setSolrUrl(solrUrl);
       SolrHelper solrHelper =
-          new SolrHelper().withSolrClient(this.solrService.getSolrClientForIndexing());
+          new SolrHelper(this.solrService.getSolrClientForIndexing())
+              .withBatchSize(solrBatchSize)
+              .withGeometryValidationRule(solrGeometryValidationRule);
       GeoService geoService = geoServiceRepository.findById("snapshot-geoserver").orElseThrow();
       Application defaultApp = applicationRepository.findByName("default");
 

--- a/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
@@ -1440,7 +1440,8 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
       final String solrUrl =
           "http://" + (connectToSpatialDbsAtLocalhost ? "127.0.0.1" : "solr") + ":8983/solr/";
       this.solrService.setSolrUrl(solrUrl);
-      SolrHelper solrHelper = new SolrHelper(this.solrService.getSolrClientForIndexing());
+      SolrHelper solrHelper =
+          new SolrHelper().withSolrClient(this.solrService.getSolrClientForIndexing());
       GeoService geoService = geoServiceRepository.findById("snapshot-geoserver").orElseThrow();
       Application defaultApp = applicationRepository.findByName("default");
 

--- a/src/main/java/org/tailormap/api/controller/SearchController.java
+++ b/src/main/java/org/tailormap/api/controller/SearchController.java
@@ -50,6 +50,9 @@ public class SearchController {
   private final SearchIndexRepository searchIndexRepository;
   private final SolrService solrService;
 
+  @Value("${tailormap-api.solr-query-timeout-seconds:7}")
+  private int solrQueryTimeout;
+
   @Value("${tailormap-api.pageSize:100}")
   private int numResultsToReturn;
 
@@ -91,7 +94,7 @@ public class SearchController {
                             .formatted(appTreeLayerNode.getLayerName())));
 
     try (SolrClient solrClient = solrService.getSolrClientForSearching();
-        SolrHelper solrHelper = new SolrHelper().withSolrClient(solrClient)) {
+        SolrHelper solrHelper = new SolrHelper(solrClient).withQueryTimeout(solrQueryTimeout)) {
       final SearchResponse searchResponse =
           solrHelper.findInIndex(
               searchIndex,

--- a/src/main/java/org/tailormap/api/controller/SearchController.java
+++ b/src/main/java/org/tailormap/api/controller/SearchController.java
@@ -91,7 +91,7 @@ public class SearchController {
                             .formatted(appTreeLayerNode.getLayerName())));
 
     try (SolrClient solrClient = solrService.getSolrClientForSearching();
-        SolrHelper solrHelper = new SolrHelper(solrClient)) {
+        SolrHelper solrHelper = new SolrHelper().withSolrClient(solrClient)) {
       final SearchResponse searchResponse =
           solrHelper.findInIndex(
               searchIndex,

--- a/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
@@ -20,6 +20,7 @@ import org.apache.solr.client.solrj.response.SolrPingResponse;
 import org.apache.solr.common.SolrException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -50,6 +51,15 @@ public class SolrAdminController {
   private final FeatureTypeRepository featureTypeRepository;
   private final SearchIndexRepository searchIndexRepository;
   private final SolrService solrService;
+
+  @Value("${tailormap-api.solr-batch-size:1000}")
+  private int solrBatchSize;
+
+  @Value("${tailormap-api.solr-query-timeout-seconds:7}")
+  private int solrQueryTimeout;
+
+  @Value("${tailormap-api.solr-geometry-validation-rule:repairBuffer0}")
+  private String solrGeometryValidationRule;
 
   public SolrAdminController(
       FeatureSourceFactoryHelper featureSourceFactoryHelper,
@@ -172,7 +182,10 @@ public class SolrAdminController {
         (null == searchIndex.getLastIndexed()
             || searchIndex.getStatus() == SearchIndex.Status.INITIAL);
     try (SolrClient solrClient = solrService.getSolrClientForIndexing();
-        SolrHelper solrHelper = new SolrHelper().withSolrClient(solrClient)) {
+        SolrHelper solrHelper =
+            new SolrHelper(solrClient)
+                .withBatchSize(solrBatchSize)
+                .withGeometryValidationRule(solrGeometryValidationRule)) {
       searchIndex =
           solrHelper.addFeatureTypeIndex(
               searchIndex, indexingFT, featureSourceFactoryHelper, searchIndexRepository);
@@ -223,7 +236,7 @@ public class SolrAdminController {
   @Transactional
   public ResponseEntity<?> clearIndex(@PathVariable Long searchIndexId) {
     try (SolrClient solrClient = solrService.getSolrClientForSearching();
-        SolrHelper solrHelper = new SolrHelper().withSolrClient(solrClient)) {
+        SolrHelper solrHelper = new SolrHelper(solrClient).withQueryTimeout(solrQueryTimeout)) {
       solrHelper.clearIndexForLayer(searchIndexId);
       // do not delete the SearchIndex metadata object
       // searchIndexRepository.findById(searchIndexId).ifPresent(searchIndexRepository::delete);

--- a/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
@@ -172,7 +172,7 @@ public class SolrAdminController {
         (null == searchIndex.getLastIndexed()
             || searchIndex.getStatus() == SearchIndex.Status.INITIAL);
     try (SolrClient solrClient = solrService.getSolrClientForIndexing();
-        SolrHelper solrHelper = new SolrHelper(solrClient)) {
+        SolrHelper solrHelper = new SolrHelper().withSolrClient(solrClient)) {
       searchIndex =
           solrHelper.addFeatureTypeIndex(
               searchIndex, indexingFT, featureSourceFactoryHelper, searchIndexRepository);
@@ -223,7 +223,7 @@ public class SolrAdminController {
   @Transactional
   public ResponseEntity<?> clearIndex(@PathVariable Long searchIndexId) {
     try (SolrClient solrClient = solrService.getSolrClientForSearching();
-        SolrHelper solrHelper = new SolrHelper(solrClient)) {
+        SolrHelper solrHelper = new SolrHelper().withSolrClient(solrClient)) {
       solrHelper.clearIndexForLayer(searchIndexId);
       // do not delete the SearchIndex metadata object
       // searchIndexRepository.findById(searchIndexId).ifPresent(searchIndexRepository::delete);

--- a/src/main/java/org/tailormap/api/scheduling/IndexTask.java
+++ b/src/main/java/org/tailormap/api/scheduling/IndexTask.java
@@ -80,7 +80,7 @@ public class IndexTask extends QuartzJobBean implements Task {
             .orElseThrow(() -> new JobExecutionException("Feature type not found"));
 
     try (SolrClient solrClient = solrService.getSolrClientForIndexing();
-        SolrHelper solrHelper = new SolrHelper(solrClient)) {
+        SolrHelper solrHelper = new SolrHelper().withSolrClient(solrClient)) {
 
       searchIndex.setStatus(SearchIndex.Status.INDEXING);
       searchIndex = searchIndexRepository.save(searchIndex);

--- a/src/main/java/org/tailormap/api/scheduling/IndexTask.java
+++ b/src/main/java/org/tailormap/api/scheduling/IndexTask.java
@@ -20,6 +20,7 @@ import org.quartz.PersistJobDataAfterExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.NonNull;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 import org.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
@@ -37,9 +38,15 @@ public class IndexTask extends QuartzJobBean implements Task {
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final FeatureSourceFactoryHelper featureSourceFactoryHelper;
-  private final SolrService solrService;
   private final FeatureTypeRepository featureTypeRepository;
   private final SearchIndexRepository searchIndexRepository;
+  private final SolrService solrService;
+
+  @Value("${tailormap-api.solr-batch-size:1000}")
+  private int solrBatchSize;
+
+  @Value("${tailormap-api.solr-geometry-validation-rule:repairBuffer0}")
+  private String solrGeometryValidationRule;
 
   private long indexId;
   private String description;
@@ -80,7 +87,10 @@ public class IndexTask extends QuartzJobBean implements Task {
             .orElseThrow(() -> new JobExecutionException("Feature type not found"));
 
     try (SolrClient solrClient = solrService.getSolrClientForIndexing();
-        SolrHelper solrHelper = new SolrHelper().withSolrClient(solrClient)) {
+        SolrHelper solrHelper =
+            new SolrHelper(solrClient)
+                .withBatchSize(solrBatchSize)
+                .withGeometryValidationRule(solrGeometryValidationRule)) {
 
       searchIndex.setStatus(SearchIndex.Status.INDEXING);
       searchIndex = searchIndexRepository.save(searchIndex);

--- a/src/main/java/org/tailormap/api/solr/SolrService.java
+++ b/src/main/java/org/tailormap/api/solr/SolrService.java
@@ -20,6 +20,21 @@ public class SolrService {
   @Value("${tailormap-api.solr-core-name:tailormap}")
   private String solrCoreName;
 
+  @Value("${tailormap-api.solr-queue-size:100}")
+  private int solrQueueSize;
+
+  @Value("${tailormap-api.solr-connection-timeout-millis:60000}")
+  private int solrConnectionTimeout;
+
+  @Value("${tailormap-api.solr-request-timeout-millis:10000}")
+  private int solrRequestTimeout;
+
+  @Value("${tailormap-api.solr-idle-timeout-millis:10000}")
+  private int solrIdleTimeout;
+
+  @Value("${tailormap-api.solr-queue-consumer-threads:10}")
+  private int solrQueueThreads;
+
   /**
    * Get a concurrent update Solr client for bulk operations.
    *
@@ -30,11 +45,29 @@ public class SolrService {
             this.solrUrl + this.solrCoreName,
             new Http2SolrClient.Builder()
                 .withFollowRedirects(true)
-                .withConnectionTimeout(10000, TimeUnit.MILLISECONDS)
-                .withRequestTimeout(60000, TimeUnit.MILLISECONDS)
+                .withConnectionTimeout(solrConnectionTimeout, TimeUnit.MILLISECONDS)
+                .withRequestTimeout(solrRequestTimeout, TimeUnit.MILLISECONDS)
+                // Set maxConnectionsPerHost for http1 connections,
+                // maximum number http2 connections is limited to 4
+                // .withMaxConnectionsPerHost(10)
+                .withIdleTimeout(solrIdleTimeout, TimeUnit.MILLISECONDS)
                 .build())
-        .withQueueSize(SolrHelper.SOLR_BATCH_SIZE * 2)
-        .withThreadCount(10)
+        /*
+        The maximum number of requests buffered by the SolrClient's internal queue before being processed by background threads.
+        This value should be carefully paired with the number of queue-consumer threads.
+        A queue with a maximum size set too high may require more memory.
+        A queue with a maximum size set too low may suffer decreased throughput as SolrClient.request(SolrRequest)
+        calls block waiting to add requests to the queue.
+        If not set, this defaults to 10.
+        */
+        .withQueueSize(solrQueueSize)
+        /*
+        The maximum number of threads used to empty ConcurrentUpdateHttp2SolrClients queue.
+        Threads are created when documents are added to the client's internal queue and exit when no updates remain in the queue.
+        This value should be carefully paired with the maximum queue capacity.
+        A client with too few threads may suffer decreased throughput as the queue fills up and SolrClient.request(SolrRequest)
+        calls block waiting to add requests to the queue. */
+        .withThreadCount(solrQueueThreads)
         .build();
   }
 
@@ -45,7 +78,7 @@ public class SolrService {
    */
   public SolrClient getSolrClientForSearching() {
     return new Http2SolrClient.Builder(this.solrUrl + this.solrCoreName)
-        .withConnectionTimeout(10, TimeUnit.SECONDS)
+        .withConnectionTimeout(solrConnectionTimeout, TimeUnit.MILLISECONDS)
         .withFollowRedirects(true)
         .build();
   }

--- a/src/main/java/org/tailormap/api/solr/SolrService.java
+++ b/src/main/java/org/tailormap/api/solr/SolrService.java
@@ -7,7 +7,6 @@ package org.tailormap.api.solr;
 
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.client.solrj.impl.ConcurrentUpdateHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -20,20 +19,14 @@ public class SolrService {
   @Value("${tailormap-api.solr-core-name:tailormap}")
   private String solrCoreName;
 
-  @Value("${tailormap-api.solr-queue-size:100}")
-  private int solrQueueSize;
-
-  @Value("${tailormap-api.solr-connection-timeout-millis:60000}")
+  @Value("${tailormap-api.solr-connection-timeout-seconds:60}")
   private int solrConnectionTimeout;
 
-  @Value("${tailormap-api.solr-request-timeout-millis:10000}")
+  @Value("${tailormap-api.solr-request-timeout-seconds:240}")
   private int solrRequestTimeout;
 
-  @Value("${tailormap-api.solr-idle-timeout-millis:10000}")
+  @Value("${tailormap-api.solr-idle-timeout-seconds:10}")
   private int solrIdleTimeout;
-
-  @Value("${tailormap-api.solr-queue-consumer-threads:10}")
-  private int solrQueueThreads;
 
   /**
    * Get a concurrent update Solr client for bulk operations.
@@ -41,33 +34,14 @@ public class SolrService {
    * @return the Solr client
    */
   public SolrClient getSolrClientForIndexing() {
-    return new ConcurrentUpdateHttp2SolrClient.Builder(
-            this.solrUrl + this.solrCoreName,
-            new Http2SolrClient.Builder()
-                .withFollowRedirects(true)
-                .withConnectionTimeout(solrConnectionTimeout, TimeUnit.MILLISECONDS)
-                .withRequestTimeout(solrRequestTimeout, TimeUnit.MILLISECONDS)
-                // Set maxConnectionsPerHost for http1 connections,
-                // maximum number http2 connections is limited to 4
-                // .withMaxConnectionsPerHost(10)
-                .withIdleTimeout(solrIdleTimeout, TimeUnit.MILLISECONDS)
-                .build())
-        /*
-        The maximum number of requests buffered by the SolrClient's internal queue before being processed by background threads.
-        This value should be carefully paired with the number of queue-consumer threads.
-        A queue with a maximum size set too high may require more memory.
-        A queue with a maximum size set too low may suffer decreased throughput as SolrClient.request(SolrRequest)
-        calls block waiting to add requests to the queue.
-        If not set, this defaults to 10.
-        */
-        .withQueueSize(solrQueueSize)
-        /*
-        The maximum number of threads used to empty ConcurrentUpdateHttp2SolrClients queue.
-        Threads are created when documents are added to the client's internal queue and exit when no updates remain in the queue.
-        This value should be carefully paired with the maximum queue capacity.
-        A client with too few threads may suffer decreased throughput as the queue fills up and SolrClient.request(SolrRequest)
-        calls block waiting to add requests to the queue. */
-        .withThreadCount(solrQueueThreads)
+    return new Http2SolrClient.Builder(this.solrUrl + this.solrCoreName)
+        .withFollowRedirects(true)
+        .withConnectionTimeout(solrConnectionTimeout, TimeUnit.SECONDS)
+        .withRequestTimeout(solrRequestTimeout, TimeUnit.SECONDS)
+        // Set maxConnectionsPerHost for http1 connections,
+        // maximum number http2 connections is limited to 4
+        // .withMaxConnectionsPerHost(10)
+        .withIdleTimeout(solrIdleTimeout, TimeUnit.SECONDS)
         .build();
   }
 
@@ -78,7 +52,7 @@ public class SolrService {
    */
   public SolrClient getSolrClientForSearching() {
     return new Http2SolrClient.Builder(this.solrUrl + this.solrCoreName)
-        .withConnectionTimeout(solrConnectionTimeout, TimeUnit.MILLISECONDS)
+        .withConnectionTimeout(solrConnectionTimeout, TimeUnit.SECONDS)
         .withFollowRedirects(true)
         .build();
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,16 +49,19 @@ tailormap-api.oidc.show-for-viewer=${OIDC_SHOW_FOR_VIEWER:false}
 # note trailing slash on url
 tailormap-api.solr-url=${SOLR_URL:#{"http://solr:8983/solr/"}}
 tailormap-api.solr-core-name=${SOLR_CORE_NAME:tailormap}
-# the number of documents that are submitted per batch to the Solr service
-tailormap-api.solr-batch-size=1000
-tailormap-api.solr-queue-size=100
-tailormap-api.solr-queue-consumer-threads=10
-tailormap-api.solr-request-timeout-millis=60000
-tailormap-api.solr-connection-timeout-millis=10000
-tailormap-api.solr-query-timeout-millis=7000
-tailormap-api.solr-idle-timeout-millis=10000
-#see https://locationtech.github.io/spatial4j/apidocs/org/locationtech/spatial4j/context/jts/ValidationRule.html
-# note that changing this value will require a recreation of the schema and subsequent reindexing of the data
+# the number of documents that are submitted per batch to the external Solr service
+tailormap-api.solr-batch-size=5000
+# http/2 request timeout for solr client
+tailormap-api.solr-request-timeout-seconds=240
+# http/2 connection timeout for solr client
+tailormap-api.solr-connection-timeout-seconds=60
+# http/2 idle timeout, to close lingering connections to solr
+tailormap-api.solr-idle-timeout-seconds=10
+# should be less than the Solr idle timeout
+tailormap-api.solr-query-timeout-seconds=7
+# one of "error", "none", "repairBuffer0", "repairConvexHull"
+# Note that changing this value will require a recreation of the Solr schema/core
+# and subsequent reindexing of the data
 tailormap-api.solr-geometry-validation-rule=repairBuffer0
 
 # in the tailormap-viewer Docker Compose stack this is changed to 0.0.0.0

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,17 @@ tailormap-api.oidc.show-for-viewer=${OIDC_SHOW_FOR_VIEWER:false}
 # note trailing slash on url
 tailormap-api.solr-url=${SOLR_URL:#{"http://solr:8983/solr/"}}
 tailormap-api.solr-core-name=${SOLR_CORE_NAME:tailormap}
+# the number of documents that are submitted per batch to the Solr service
+tailormap-api.solr-batch-size=1000
+tailormap-api.solr-queue-size=100
+tailormap-api.solr-queue-consumer-threads=10
+tailormap-api.solr-request-timeout-millis=60000
+tailormap-api.solr-connection-timeout-millis=10000
+tailormap-api.solr-query-timeout-millis=7000
+tailormap-api.solr-idle-timeout-millis=10000
+#see https://locationtech.github.io/spatial4j/apidocs/org/locationtech/spatial4j/context/jts/ValidationRule.html
+# note that changing this value will require a recreation of the schema and subsequent reindexing of the data
+tailormap-api.solr-geometry-validation-rule=repairBuffer0
 
 # in the tailormap-viewer Docker Compose stack this is changed to 0.0.0.0
 server.address=localhost


### PR DESCRIPTION
[![HTM-1332](https://badgen.net/badge/JIRA/HTM-1332/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1332) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Use a Http2SolrClient (the async, non-blocking and general-purpose client that leverage HTTP/2 using the Jetty Http library) instead of a `ConcurrentUpdateHttp2SolrClient` (geared towards indexing-centric workloads. Buffers documents internally before sending larger batches to Solr) to prevent timeouts when submitting large sets of documents. This trades stability over performance; however many connection and indexing parameters can now be tuned for deployment.

- [x] Expose all possibly relevant Solr parameters as (runtime/configurable) properties
- [x] update/tweak properties to allow large testcase to pass, possibly ⛓️‍💥breaking⛓️‍💥 as it is now possible to change the `tm_geometry_rpt` Solr field type geometry validation rule

[HTM-1332]: https://b3partners.atlassian.net/browse/HTM-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ