### PR TITLE
Allow priority to be null when creating a new task

### DIFF
--- a/src/main/java/org/tailormap/api/repository/events/SearchIndexEventHandler.java
+++ b/src/main/java/org/tailormap/api/repository/events/SearchIndexEventHandler.java
@@ -100,7 +100,10 @@ public class SearchIndexEventHandler {
                     searchIndex.getSchedule().getDescription(),
                     IndexTask.INDEX_KEY,
                     searchIndex.getId().toString()));
-        jobDataMap.setPriority(searchIndex.getSchedule().getPriority());
+        if (null != searchIndex.getSchedule().getPriority()
+            && searchIndex.getSchedule().getPriority() > 0) {
+          jobDataMap.put(Task.PRIORITY_KEY, searchIndex.getSchedule().getPriority());
+        }
         final UUID uuid =
             taskManagerService.createTask(
                 IndexTask.class, jobDataMap, searchIndex.getSchedule().getCronExpression());


### PR DESCRIPTION
This was previously added for updating an existing task, but not yet for a new task.