### PR TITLE
Add a devcontainer config

### DIFF
--- a/build/ci/docker-compose.yml
+++ b/build/ci/docker-compose.yml
@@ -4,9 +4,10 @@
 name: 'tailormap-ci'
 
 volumes:
-  postgis-db:
-  sqlserver-db:
-  oracle-db:
+  postgres-data:
+  postgis-data:
+  sqlserver-data:
+  oracle-data:
   solr-data:
 
 
@@ -25,6 +26,8 @@ services:
       POSTGRES_DB: tailormap
     ports:
       - "127.0.0.1:5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
     networks:
       - tailormap-ci
     healthcheck:
@@ -42,7 +45,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-fa6efb5b-075b-4b7b-aab0-96108cd77e76}
       GEODATA_PASSWORD: ${GEODATA_PASSWORD:-980f1c8A-25933b2}
     volumes:
-      - postgis-db:/var/lib/postgresql/data
+      - postgis-data:/var/lib/postgresql/data
     ports:
       - "127.0.0.1:54322:5432"
     networks:
@@ -63,7 +66,7 @@ services:
       GEODATA_PASSWORD: ${GEODATA_PASSWORD:-980f1c8A-25933b2}
       ACCEPT_EULA: Y
     volumes:
-      - sqlserver-db:/var/opt/mssql
+      - sqlserver-data:/var/opt/mssql
     ports:
       - "127.0.0.1:1433:1433"
     networks:
@@ -86,7 +89,7 @@ services:
       APP_USER_PASSWORD: ${GEODATA_PASSWORD:-980f1c8A-25933b2}
       GEODATA_PASSWORD: ${GEODATA_PASSWORD:-980f1c8A-25933b2}
     volumes:
-      - oracle-db:/opt/oracle/oradata
+      - oracle-data:/opt/oracle/oradata
     ports:
       - "127.0.0.1:1521:1521"
     networks:


### PR DESCRIPTION
this may still need some work, but will/should enable e.g. IntelliJ to connect to a remote instance which could be equipped with more resources, eg from home to a server or office desktop