### PR TITLE
HTM-1366 | HTM-1367: Indexing process summary information should be stored as a json blob

### DIFF
--- a/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/SolrAdminController.java
@@ -38,6 +38,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import org.tailormap.api.admin.model.SearchIndexSummary;
 import org.tailormap.api.persistence.SearchIndex;
 import org.tailormap.api.persistence.TMFeatureSource;
 import org.tailormap.api.persistence.TMFeatureType;
@@ -291,7 +292,9 @@ public class SolrAdminController {
 
     if (TMFeatureSource.Protocol.WFS.equals(indexingFT.getFeatureSource().getProtocol())) {
       // the search index should not exist for WFS feature types, but test just in case
-      searchIndex.setStatus(SearchIndex.Status.ERROR).setComment("WFS indexing not supported");
+      searchIndex
+          .setStatus(SearchIndex.Status.ERROR)
+          .setSummary(new SearchIndexSummary().errorMessage("WFS indexing not supported"));
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Layer does not have valid feature type for indexing");
     }
@@ -336,7 +339,7 @@ public class SolrAdminController {
       searchIndex
           .setLastIndexed(null)
           .setStatus(SearchIndex.Status.INITIAL)
-          .setComment("Index cleared");
+          .setSummary(new SearchIndexSummary().total(0));
       searchIndexRepository.save(searchIndex);
     } catch (IOException | SolrServerException | NoSuchElementException e) {
       logger.warn("Error clearing index", e);

--- a/src/main/java/org/tailormap/api/persistence/SearchIndex.java
+++ b/src/main/java/org/tailormap/api/persistence/SearchIndex.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.annotations.Type;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.tailormap.api.admin.model.SearchIndexSummary;
 import org.tailormap.api.admin.model.TaskSchedule;
 import org.tailormap.api.persistence.listener.EntityEventPublisher;
 
@@ -53,8 +54,11 @@ public class SearchIndex implements Serializable {
   @Valid
   private List<String> searchDisplayFieldsUsed = new ArrayList<>();
 
-  @Column(columnDefinition = "text")
-  private String comment;
+  @JsonProperty("summary")
+  @Type(value = io.hypersistence.utils.hibernate.type.json.JsonBinaryType.class)
+  @Column(columnDefinition = "jsonb")
+  @Valid
+  private SearchIndexSummary summary;
 
   /** Date and time of last index creation. */
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
@@ -118,15 +122,6 @@ public class SearchIndex implements Serializable {
     return this;
   }
 
-  public String getComment() {
-    return comment;
-  }
-
-  public SearchIndex setComment(String comment) {
-    this.comment = comment;
-    return this;
-  }
-
   public OffsetDateTime getLastIndexed() {
     return lastIndexed;
   }
@@ -151,6 +146,15 @@ public class SearchIndex implements Serializable {
 
   public SearchIndex setSchedule(@Valid TaskSchedule schedule) {
     this.schedule = schedule;
+    return this;
+  }
+
+  public SearchIndexSummary getSummary() {
+    return summary;
+  }
+
+  public SearchIndex setSummary(SearchIndexSummary summary) {
+    this.summary = summary;
     return this;
   }
 

--- a/src/main/java/org/tailormap/api/scheduling/IndexTask.java
+++ b/src/main/java/org/tailormap/api/scheduling/IndexTask.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.NonNull;
 import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.tailormap.api.admin.model.SearchIndexSummary;
 import org.tailormap.api.admin.model.ServerSentEvent;
 import org.tailormap.api.admin.model.TaskProgressEvent;
 import org.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
@@ -108,8 +109,7 @@ public class IndexTask extends QuartzJobBean implements Task {
                 .withBatchSize(solrBatchSize)
                 .withGeometryValidationRule(solrGeometryValidationRule)) {
 
-      searchIndex.setStatus(SearchIndex.Status.INDEXING);
-      searchIndex = searchIndexRepository.save(searchIndex);
+      searchIndex = searchIndexRepository.save(searchIndex.setStatus(SearchIndex.Status.INDEXING));
 
       searchIndex =
           solrHelper.addFeatureTypeIndex(
@@ -119,8 +119,7 @@ public class IndexTask extends QuartzJobBean implements Task {
               searchIndexRepository,
               this::taskProgress,
               UUID.fromString(context.getTrigger().getJobKey().getName()));
-      searchIndex = searchIndex.setStatus(SearchIndex.Status.INDEXED);
-      searchIndexRepository.save(searchIndex);
+      searchIndex = searchIndexRepository.save(searchIndex.setStatus(SearchIndex.Status.INDEXED));
       persistedJobData.put(
           "executions", (1 + (int) context.getMergedJobDataMap().getOrDefault("executions", 0)));
       persistedJobData.put("lastExecutionFinished", Instant.now());
@@ -128,12 +127,14 @@ public class IndexTask extends QuartzJobBean implements Task {
       context.setResult("Index task executed successfully");
     } catch (UnsupportedOperationException | IOException | SolrServerException | SolrException e) {
       logger.error("Error indexing", e);
-      searchIndex.setStatus(SearchIndex.Status.ERROR).setComment(e.getMessage());
       persistedJobData.put("lastExecutionFinished", null);
       persistedJobData.put(
           Task.LAST_RESULT_KEY,
           "Index task failed with " + e.getMessage() + ". Check logs for details");
-      searchIndexRepository.save(searchIndex);
+      searchIndexRepository.save(
+          searchIndex
+              .setStatus(SearchIndex.Status.ERROR)
+              .setSummary(new SearchIndexSummary().errorMessage(e.getMessage())));
       context.setResult("Error indexing. Check logs for details.");
       throw new JobExecutionException("Error indexing", e);
     }

--- a/src/main/resources/db/migration/V13__add_solr_index_summary_delete_comment_columns.sql
+++ b/src/main/resources/db/migration/V13__add_solr_index_summary_delete_comment_columns.sql
@@ -1,0 +1,4 @@
+alter table if exists search_index
+    drop column comment;
+alter table if exists search_index
+    add column summary jsonb default null;

--- a/src/main/resources/openapi/admin-schemas.yaml
+++ b/src/main/resources/openapi/admin-schemas.yaml
@@ -100,3 +100,33 @@ components:
           description: 'Priority of the task'
           type: integer
           nullable: true
+
+    SearchIndexSummary:
+      description: 'Summary of a search index run. This is created/updated when the index is finished.'
+      type: object
+      properties:
+        total:
+          description: 'Total number of features counted for indexing. When 0 or null, the index was cleared.'
+          type: integer
+          format: int32
+          nullable: true
+        skippedCounter:
+          description: 'Number of features skipped during indexing.'
+          type: integer
+          format: int32
+          nullable: true
+        startedAt:
+          description: 'Zoned date-time when the task started.'
+          type: string
+          format: date-time
+          nullable: true
+          example: '2024-12-13T11:30:40.863829185+01:00'
+        duration:
+          description: 'Time taken to index the source in seconds.'
+          type: number
+          format: double
+          nullable: true
+        errorMessage:
+          description: 'Error message if the task failed. Check the status field of the search index.'
+          type: string
+          nullable: true


### PR DESCRIPTION
[![HTM-1366](https://badgen.net/badge/JIRA/HTM-1366/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1366) [![HTM-1367](https://badgen.net/badge/JIRA/HTM-1367/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1367) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- [x] HTM-1366: replace `SearchIndex#comment` with `SearchIndex#summary` in datamodel and persistence
- [x] HTM-1367: Update usage of `setComment()` and documentation in the API

_**Note** that this requires changes in the viewer_:https://github.com/Tailormap/tailormap-viewer/pull/783

[HTM-1366]: https://b3partners.atlassian.net/browse/HTM-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HTM-1367]: https://b3partners.atlassian.net/browse/HTM-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ