### PR TITLE
Fix: use doesNotHaveJsonPath() when expecting that a path should not exist

### DIFF
--- a/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
@@ -814,6 +814,12 @@ public class PopulateTestData {
                                       new FeatureTypeRef()
                                           .featureSourceId(featureSources.get("postgis").getId())
                                           .featureTypeName("begroeidterreindeel")),
+                              "postgis:bak",
+                              new GeoServiceLayerSettings()
+                                  .featureType(
+                                      new FeatureTypeRef()
+                                          .featureSourceId(featureSources.get("postgis").getId())
+                                          .featureTypeName("bak")),
                               "sqlserver:wegdeel",
                               new GeoServiceLayerSettings()
                                   .attribution(
@@ -917,6 +923,25 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
               ft.getSettings().addAttributeOrderItem("identificatie");
               ft.getSettings().addAttributeOrderItem("bronhouder");
               ft.getSettings().addAttributeOrderItem("class");
+            });
+
+    featureSources.get("postgis").getFeatureTypes().stream()
+        .filter(ft -> ft.getName().equals("bak"))
+        .findFirst()
+        .ifPresent(
+            ft -> {
+              ft.getSettings().addHideAttributesItem("gmlid");
+              ft.getSettings().addHideAttributesItem("lv_publicatiedatum");
+              ft.getSettings().addHideAttributesItem("creationdate");
+              ft.getSettings().addHideAttributesItem("tijdstipregistratie");
+              ft.getSettings().addHideAttributesItem("eindregistratie");
+              ft.getSettings().addHideAttributesItem("terminationdate");
+              ft.getSettings().addHideAttributesItem("inonderzoek");
+              ft.getSettings().addHideAttributesItem("relatievehoogteligging");
+              ft.getSettings().addHideAttributesItem("bgt_status");
+              ft.getSettings().addHideAttributesItem("plus_status");
+              ft.getSettings().addHideAttributesItem("function_");
+              ft.getSettings().addHideAttributesItem("plus_type");
             });
   }
 
@@ -1030,6 +1055,7 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
                                     "lyr:bestuurlijkegebieden-proxied:Provinciegebied",
                                     "lyr:pdok-kadaster-bestuurlijkegebieden:Gemeentegebied",
                                     "lyr:snapshot-geoserver:postgis:begroeidterreindeel",
+                                    "lyr:snapshot-geoserver:postgis:bak",
                                     "lyr:snapshot-geoserver:sqlserver:wegdeel",
                                     "lyr:snapshot-geoserver:oracle:WATERDEEL",
                                     "lyr:snapshot-geoserver:BGT",
@@ -1067,6 +1093,13 @@ Deze provincie heet **{{naam}}** en ligt in _{{ligtInLandNaam}}_.
                             .serviceId("snapshot-geoserver")
                             .layerName("postgis:begroeidterreindeel")
                             .visible(true))
+                    .addLayerNodesItem(
+                        new AppTreeLayerNode()
+                            .objectType("AppTreeLayerNode")
+                            .id("lyr:snapshot-geoserver:postgis:bak")
+                            .serviceId("snapshot-geoserver")
+                            .layerName("postgis:bak")
+                            .visible(false))
                     .addLayerNodesItem(
                         new AppTreeLayerNode()
                             .objectType("AppTreeLayerNode")

--- a/src/test/java/org/tailormap/api/controller/FeaturesControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/FeaturesControllerIntegrationTest.java
@@ -270,9 +270,9 @@ class FeaturesControllerIntegrationTest {
 
   private static ResultMatcher[] provinciesWFSResultMatchers() {
     return new ResultMatcher[] {
-      jsonPath("$.features[0].attributes.identificatie").doesNotExist(),
-      jsonPath("$.features[0].attributes.ligtInLandCode").doesNotExist(),
-      jsonPath("$.features[0].attributes.fuuid").doesNotExist(),
+      jsonPath("$.features[0].attributes.identificatie").doesNotHaveJsonPath(),
+      jsonPath("$.features[0].attributes.ligtInLandCode").doesNotHaveJsonPath(),
+      jsonPath("$.features[0].attributes.fuuid").doesNotHaveJsonPath(),
       jsonPath("$.columnMetadata").isArray(),
       jsonPath("$.columnMetadata").isNotEmpty(),
       jsonPath("$.template").isNotEmpty(),

--- a/src/test/java/org/tailormap/api/controller/LayerDescriptionControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerDescriptionControllerIntegrationTest.java
@@ -58,8 +58,8 @@ class LayerDescriptionControllerIntegrationTest {
         .andExpect(
             jsonPath("$.attributes[?(@.key == 'relatievehoogteligging')].type").value("integer"))
         .andExpectAll(
-            jsonPath("$.attributes[?(@.key == 'terminationdate')]").doesNotExist(),
-            jsonPath("$.attributes[?(@.key == 'geom_kruinlijn')]").doesNotExist())
+            jsonPath("$.attributes[?(@.key == 'terminationdate')]").doesNotHaveJsonPath(),
+            jsonPath("$.attributes[?(@.key == 'geom_kruinlijn')]").doesNotHaveJsonPath())
         .andExpect(jsonPath("$.attributes[?(@.key == 'gmlid')].nullable").value(false))
         .andExpect(jsonPath("$.attributes[?(@.key == 'gmlid')].editable").value(false))
         .andExpect(jsonPath("$.editable").value(true));

--- a/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
@@ -225,8 +225,8 @@ class LayerExportControllerIntegrationTest {
         .andExpect(jsonPath("$.type").value("FeatureCollection"))
         .andExpect(jsonPath("$.features.length()").value(14))
         // terminationdate,geom_kruinlijn are hidden attributes
-        .andExpect(jsonPath("$.features[0].properties.terminationdate").doesNotExist())
-        .andExpect(jsonPath("$.features[0].properties.geom_kruinlijn").doesNotExist());
+        .andExpect(jsonPath("$.features[0].properties.terminationdate").doesNotHaveJsonPath())
+        .andExpect(jsonPath("$.features[0].properties.geom_kruinlijn").doesNotHaveJsonPath());
   }
 
   @Test

--- a/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junitpioneer.jupiter.DisabledUntil;
+import org.junitpioneer.jupiter.Issue;
 import org.junitpioneer.jupiter.Stopwatch;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -210,6 +212,10 @@ class LayerExportControllerIntegrationTest {
   }
 
   @Test
+  @Issue("https://b3partners.atlassian.net/browse/SUPPORT-14840")
+  @DisabledUntil(
+      date = "2025-01-23",
+      reason = "This should be fixed in GeoServer 2.26.2, which is planned for 2025-01-18")
   void shouldNotExportHiddenAttributesInGeoJSON() throws Exception {
     final String url = apiBasePath + layerBakPostgis + downloadPath;
     mockMvc

--- a/src/test/java/org/tailormap/api/controller/PageControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/PageControllerIntegrationTest.java
@@ -62,7 +62,7 @@ class PageControllerIntegrationTest {
                 .exists())
         .andExpect(
             jsonPath("$.tiles[?(@.applicationUrl == '/app/secured' && @.title == 'Secured app')]")
-                .doesNotExist());
+                .doesNotHaveJsonPath());
   }
 
   @Test
@@ -91,7 +91,7 @@ class PageControllerIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath(aboutItemJsonPath).value("/page/about"))
-        .andExpect(jsonPath(b3pWebsiteItemJsonPath).doesNotExist());
+        .andExpect(jsonPath(b3pWebsiteItemJsonPath).doesNotHaveJsonPath());
 
     mockMvc
         .perform(

--- a/src/test/java/org/tailormap/api/controller/TestUrls.java
+++ b/src/test/java/org/tailormap/api/controller/TestUrls.java
@@ -11,6 +11,7 @@ public interface TestUrls {
       "/app/default/layer/lyr:pdok-kadaster-bestuurlijkegebieden:Provinciegebied";
   String layerBegroeidTerreindeelPostgis =
       "/app/default/layer/lyr:snapshot-geoserver:postgis:begroeidterreindeel";
+  String layerBakPostgis = "/app/default/layer/lyr:snapshot-geoserver:postgis:bak";
   String layerWaterdeelOracle = "/app/default/layer/lyr:snapshot-geoserver:oracle:WATERDEEL";
   String layerWegdeelSqlServer = "/app/default/layer/lyr:snapshot-geoserver:sqlserver:wegdeel";
   String layerOsmPolygonPostgis = "/app/default/layer/lyr:snapshot-geoserver:postgis:osm_polygon";

--- a/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
@@ -229,7 +229,7 @@ class ViewerControllerIntegrationTest {
         .andExpect(jsonPath("$.appLayers[0]").isMap())
         // Note: if the testdata was created with MAP5_URL set, the appLayers array will have 4 more
         // layers
-        .andExpect(jsonPath("$.appLayers.length()").value(13))
+        .andExpect(jsonPath("$.appLayers.length()").value(14))
         .andExpect(
             jsonPath("$.appLayers[?(@.id == 'lyr:openbasiskaart-tms:xyz')].hasAttributes")
                 .value(false))

--- a/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
@@ -160,13 +160,16 @@ class ViewerControllerIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(
-            jsonPath("$.appLayers[?(@.id == 'lyr:openbasiskaart-proxied:osm')]").doesNotExist())
-        .andExpect(jsonPath("$.services[?(@.id == 'openbasiskaart-proxied')]").doesNotExist())
+            jsonPath("$.appLayers[?(@.id == 'lyr:openbasiskaart-proxied:osm')]")
+                .doesNotHaveJsonPath())
+        .andExpect(
+            jsonPath("$.services[?(@.id == 'openbasiskaart-proxied')]").doesNotHaveJsonPath())
         .andExpect(
             jsonPath("$.appLayers[?(@.id == 'lyr:bestuurlijkegebieden-proxied:Provinciegebied')]")
-                .doesNotExist())
+                .doesNotHaveJsonPath())
         .andExpect(
-            jsonPath("$.services[?(@.id == 'bestuurlijkegebieden-proxied')]").doesNotExist());
+            jsonPath("$.services[?(@.id == 'bestuurlijkegebieden-proxied')]")
+                .doesNotHaveJsonPath());
   }
 
   @Test
@@ -181,13 +184,16 @@ class ViewerControllerIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(
-            jsonPath("$.appLayers[?(@.id == 'lyr:openbasiskaart-proxied:osm')]").doesNotExist())
-        .andExpect(jsonPath("$.services[?(@.id == 'openbasiskaart-proxied')]").doesNotExist())
+            jsonPath("$.appLayers[?(@.id == 'lyr:openbasiskaart-proxied:osm')]")
+                .doesNotHaveJsonPath())
+        .andExpect(
+            jsonPath("$.services[?(@.id == 'openbasiskaart-proxied')]").doesNotHaveJsonPath())
         .andExpect(
             jsonPath("$.appLayers[?(@.id == 'lyr:bestuurlijkegebieden-proxied:Provinciegebied')]")
-                .doesNotExist())
+                .doesNotHaveJsonPath())
         .andExpect(
-            jsonPath("$.services[?(@.id == 'bestuurlijkegebieden-proxied')]").doesNotExist());
+            jsonPath("$.services[?(@.id == 'bestuurlijkegebieden-proxied')]")
+                .doesNotHaveJsonPath());
   }
 
   @Test


### PR DESCRIPTION
…at all (not even will a null value), instead of doesNotExist() which passes for null values

Should work when a GeoServer with fix for GEOT-7673 is released.