### PR TITLE
HTM-1390: Update dependency org.springframework.boot:spring-boot-starter-parent to v3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <flyway.version>10.22.0</flyway.version>
         <hamcrest.version>3.0</hamcrest.version>
         <hibernate.version>6.6.4.Final</hibernate.version>
-        <jackson-bom.version>2.17.2</jackson-bom.version>
+        <!-- <jackson-bom.version>2.18.2</jackson-bom.version> -->
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <micrometer.version>1.13.6</micrometer.version>
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>


### PR DESCRIPTION
[![HTM-1390](https://badgen.net/badge/JIRA/HTM-1390/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1390) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[HTM-1390]: https://b3partners.atlassian.net/browse/HTM-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ