### PR TITLE
HTM-1393 | HTM-1394: Override logback version provided by Spring Boot bom from 1.5.12 to 1.5.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@ SPDX-License-Identifier: MIT
         <hibernate.version>6.6.4.Final</hibernate.version>
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
+        <logback.version>1.5.14</logback.version>
         <micrometer.version>1.13.6</micrometer.version>
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
         <oracle-database.version>23.5.0.24.07</oracle-database.version>


### PR DESCRIPTION


resolve 
- HTM-1393 / https://github.com/Tailormap/tailormap-api/security/dependabot/8
- HTM-1394 / https://github.com/Tailormap/tailormap-api/security/dependabot/9