### PR TITLE
HTM-1413: when there are no attributes left indexing could crash

### DIFF
--- a/src/main/java/org/tailormap/api/solr/SolrHelper.java
+++ b/src/main/java/org/tailormap/api/solr/SolrHelper.java
@@ -271,6 +271,12 @@ public class SolrHelper implements AutoCloseable, Constants {
     Query q = new Query(fs.getName().toString());
     // filter out any hidden properties (there should be none though)
     tmFeatureType.getSettings().getHideAttributes().forEach(propertyNames::remove);
+    if (propertyNames.isEmpty()) {
+      logger.warn("No valid properties to index for featuretype: {}, bailing out.", tmFeatureType.getName());
+      return searchIndexRepository.save(searchIndex
+          .setStatus(SearchIndex.Status.ERROR)
+          .setSummary(summary.errorMessage("No valid properties to index")));
+    }
     q.setPropertyNames(List.copyOf(propertyNames));
     q.setStartIndex(0);
     // TODO: make maxFeatures configurable?


### PR DESCRIPTION
[![HTM-1413](https://badgen.net/badge/JIRA/HTM-1413/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1413) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

because there are no fields to copy, where a NonNull is required

[HTM-1413]: https://b3partners.atlassian.net/browse/HTM-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ