### PR TITLE
SUPPORT-14840: re-enable and fix the `shouldNotExportHiddenAttributesInGeoJSON` testcase

### DIFF
--- a/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junitpioneer.jupiter.DisabledUntil;
 import org.junitpioneer.jupiter.Issue;
 import org.junitpioneer.jupiter.Stopwatch;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -188,10 +187,6 @@ class LayerExportControllerIntegrationTest {
 
   @Test
   @Issue("https://b3partners.atlassian.net/browse/SUPPORT-14840")
-  @DisabledUntil(
-      date = "2025-01-31",
-      reason =
-          "This should be fixed in GeoServer 2.26.2, which was planned for 2025-01-18, but is not yet released.")
   void shouldNotExportHiddenAttributesInGeoJSON() throws Exception {
     final String url = apiBasePath + layerBakPostgis + downloadPath;
     mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON)
@@ -205,12 +200,12 @@ class LayerExportControllerIntegrationTest {
         // all attributes are hidden except bronhouder and identificatie
         .andExpect(jsonPath("$.features[0].properties.identificatie")
             .value("P0026.8abeacd54c5b7500047b2112796cab56"))
+        .andExpect(jsonPath("$.features[0].properties.bronhouder").value("P0026"))
         .andExpect(
             jsonPath("$.features[0].properties.lv_publicatiedatum").doesNotHaveJsonPath())
         .andExpect(jsonPath("$.features[0].properties.creationdate").doesNotHaveJsonPath())
         .andExpect(
             jsonPath("$.features[0].properties.tijdstipregistratie").doesNotHaveJsonPath())
-        .andExpect(jsonPath("$.features[0].properties.bronhouder").value("P0026"))
         .andExpect(jsonPath("$.features[0].properties.inonderzoek").doesNotHaveJsonPath())
         .andExpect(jsonPath("$.features[0].properties.relatievehoogteligging")
             .doesNotHaveJsonPath())

--- a/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExportControllerIntegrationTest.java
@@ -200,18 +200,22 @@ class LayerExportControllerIntegrationTest {
         // all attributes are hidden except bronhouder and identificatie
         .andExpect(jsonPath("$.features[0].properties.identificatie")
             .value("P0026.8abeacd54c5b7500047b2112796cab56"))
+        // mandatory, but hidden attributes of the schema
+        .andExpect(
+            jsonPath("$.features[0].properties.lv_publicatiedatum").isNotEmpty())
+        .andExpect(jsonPath("$.features[0].properties.creationdate").isNotEmpty())
+        .andExpect(
+            jsonPath("$.features[0].properties.tijdstipregistratie").isNotEmpty())
         .andExpect(jsonPath("$.features[0].properties.bronhouder").value("P0026"))
-        .andExpect(
-            jsonPath("$.features[0].properties.lv_publicatiedatum").doesNotHaveJsonPath())
-        .andExpect(jsonPath("$.features[0].properties.creationdate").doesNotHaveJsonPath())
-        .andExpect(
-            jsonPath("$.features[0].properties.tijdstipregistratie").doesNotHaveJsonPath())
-        .andExpect(jsonPath("$.features[0].properties.inonderzoek").doesNotHaveJsonPath())
+        .andExpect(jsonPath("$.features[0].properties.inonderzoek").isNotEmpty())
         .andExpect(jsonPath("$.features[0].properties.relatievehoogteligging")
-            .doesNotHaveJsonPath())
-        .andExpect(jsonPath("$.features[0].properties.bgt_status").doesNotHaveJsonPath())
-        .andExpect(jsonPath("$.features[0].properties.function_").doesNotHaveJsonPath())
-        .andExpect(jsonPath("$.features[0].properties.plus_type").doesNotHaveJsonPath());
+            .isNotEmpty())
+        .andExpect(jsonPath("$.features[0].properties.bgt_status").isNotEmpty())
+        .andExpect(jsonPath("$.features[0].properties.function_").isNotEmpty())
+        .andExpect(jsonPath("$.features[0].properties.plus_type").isNotEmpty())
+        // non-mandatory attributes of the schema that were not requested
+        .andExpect(jsonPath("$.features[0].properties.eindregistratie").doesNotHaveJsonPath())
+        .andExpect(jsonPath("$.features[0].properties.terminationdate").doesNotHaveJsonPath());
   }
 
   @Test


### PR DESCRIPTION
[![SUPPORT-14840](https://badgen.net/badge/JIRA/SUPPORT-14840/pink?icon=jira)](https://b3partners.atlassian.net/browse/SUPPORT-14840) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

GeoServer was updated to 2.26.2 which should have this fixed

[SUPPORT-14840]: https://b3partners.atlassian.net/browse/SUPPORT-14840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ