### PR TITLE
Bump com.oracle.database.jdbc:ojdbc11 from 23.6.0.24.10 to 23.7.0.25.01

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ SPDX-License-Identifier: MIT
         <logback.version>1.5.14</logback.version>
         <micrometer.version>1.14.3</micrometer.version>
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
-        <oracle-database.version>23.6.0.24.10</oracle-database.version>
+        <oracle-database.version>23.7.0.25.01</oracle-database.version>
         <postgresql.version>42.7.5</postgresql.version>
         <!-- <spring-data-bom.version>2024.0.6</spring-data-bom.version> -->
         <!-- <spring-hateoas.version>2.3.3</spring-hateoas.version> -->


### PR DESCRIPTION
Bumps com.oracle.database.jdbc:ojdbc11 from 23.6.0.24.10 to 23.7.0.25.01.