### PR TITLE
[HTM-1436] Override json-smart.version to obtain a version that has fixed CVE-2024-57699

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@ SPDX-License-Identifier: MIT
         <hamcrest.version>3.0</hamcrest.version>
         <hibernate.version>6.6.7.Final</hibernate.version>
         <!-- <jackson-bom.version>2.18.2</jackson-bom.version> -->
+        <json-smart.version>2.5.2</json-smart.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <logback.version>1.5.14</logback.version>
         <micrometer.version>1.14.3</micrometer.version>


### PR DESCRIPTION
[![CVE-2024](https://badgen.net/badge/JIRA/CVE-2024/pink?icon=jira)](https://b3partners.atlassian.net/browse/CVE-2024) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[![HTM-1436](https://badgen.net/badge/JIRA/HTM-1436/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1436)




Netplex Json-smart has resolved, see: https://github.com/Tailormap/tailormap-api/security/dependabot/11 and https://github.com/Tailormap/tailormap-viewer/security/code-scanning/325

[HTM-1436]: https://b3partners.atlassian.net/browse/HTM-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ