### PR TITLE
HTM-1441: set writeable property when JDBC feature type is not read only and no composite keys are found

### DIFF
--- a/build/ci/testdata-setup.sh
+++ b/build/ci/testdata-setup.sh
@@ -16,7 +16,7 @@ while :
 do
   printf " %d" "$_WAIT"
   if [ "$POSTGIS_HEALTHY" == "healthy" ] && [ "$ORACLE_HEALTHY" == "healthy" ] && [ "$SQLSERVER_HEALTHY" == "healthy" ]; then
-    printf "\nDone waiting for databases to be ready\n"
+    printf "\nDocker containers are healthy\n"
     break
   fi
 
@@ -27,6 +27,19 @@ do
   ORACLE_HEALTHY=$(docker inspect --format="{{.State.Health.Status}}" oracle)
   SQLSERVER_HEALTHY=$(docker inspect --format="{{.State.Health.Status}}" sqlserver)
 
+done
+
+printf "\n%(%T)T Waiting for Oracle $1 database to report it is ready to use.... "
+_WAIT=0;
+while :
+do
+    printf " $_WAIT"
+    if $(docker logs oracle | grep -q 'DATABASE IS READY TO USE!'); then
+        printf "\n %(%T)TOracle $1 database is ready to use\n\n" -1
+        break
+    fi
+    sleep 10
+    _WAIT=$(($_WAIT+10))
 done
 
 printf "\nPostGIS logs:\n"

--- a/build/ci/testdata-setup.sh
+++ b/build/ci/testdata-setup.sh
@@ -43,11 +43,11 @@ do
 done
 
 printf "\nPostGIS logs:\n"
-docker logs postgis
+docker logs -t postgis
 #docker inspect postgis
 printf "\nOracle logs:\n"
-docker logs oracle
+docker logs -t oracle
 #docker inspect oracle
 printf "\nSQL Server logs:\n"
-docker logs sqlserver
+docker logs -t sqlserver
 #docker inspect sqlserver

--- a/src/main/java/org/tailormap/api/geotools/featuresources/FeatureSourceHelper.java
+++ b/src/main/java/org/tailormap/api/geotools/featuresources/FeatureSourceHelper.java
@@ -110,11 +110,7 @@ public abstract class FeatureSourceHelper {
         TMFeatureType pft = tmfs.getFeatureTypes().stream()
             .filter(ft -> ft.getName().equals(typeName))
             .findFirst()
-            .orElseGet(() -> new TMFeatureType()
-                .setName(typeName)
-                .setFeatureSource(tmfs)
-                // TODO set writeable meaningfully
-                .setWriteable(tmfs.getProtocol() == TMFeatureSource.Protocol.JDBC));
+            .orElseGet(() -> new TMFeatureType().setName(typeName).setFeatureSource(tmfs));
         if (!tmfs.getFeatureTypes().contains(pft)) {
           tmfs.getFeatureTypes().add(pft);
         }

--- a/src/test/java/org/tailormap/api/controller/EditFeatureControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/EditFeatureControllerIntegrationTest.java
@@ -37,6 +37,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.tailormap.api.StaticTestData;
@@ -440,6 +441,7 @@ class EditFeatureControllerIntegrationTest {
             .with(setServletPath(url))
             .contentType(MediaType.APPLICATION_JSON)
             .content(content))
+        .andDo(MockMvcResultHandlers.print())
         .andExpect(status().is2xxSuccessful())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.__fid").value(fid))
@@ -556,6 +558,7 @@ class EditFeatureControllerIntegrationTest {
             .content("{\"attributes\":{\"INONDERZOEK\":true,\"CLASS\":\"woeste bergbeek\",\"GEOM\":\""
                 + StaticTestData.get("waterdeel__edit_geom")
                 + "\"}}"))
+        .andDo(MockMvcResultHandlers.print())
         .andExpect(status().is2xxSuccessful())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.__fid").value(StaticTestData.get("waterdeel__fid_edit")))
@@ -682,6 +685,7 @@ class EditFeatureControllerIntegrationTest {
   void testDeleteExistingFeatureOrcl() throws Exception {
     final String url = apiBasePath + waterdeelUrlOracle + "/" + StaticTestData.get("waterdeel__fid_delete");
     mockMvc.perform(delete(url).accept(MediaType.APPLICATION_JSON).with(setServletPath(url)))
+        .andDo(MockMvcResultHandlers.print())
         .andExpect(status().is2xxSuccessful())
         .andExpect(status().is(204));
   }


### PR DESCRIPTION
[![HTM-1441](https://badgen.net/badge/JIRA/HTM-1441/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1441) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Previously a feature type was set as writeable when the feature source was JDBC, but the GeoTools JDBC data store also sets a user data read only property that more accurately reflects whether the feature type is writeable.

[HTM-1441]: https://b3partners.atlassian.net/browse/HTM-1441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ