### PR TITLE
HTM-1451: temporarily disable failing PDOK service legend test

### DIFF
--- a/src/test/java/org/tailormap/api/controller/GeoServiceProxyControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/GeoServiceProxyControllerIntegrationTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junitpioneer.jupiter.DisabledUntil;
+import org.junitpioneer.jupiter.Issue;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -109,6 +111,8 @@ class GeoServiceProxyControllerIntegrationTest {
     assertImagesEqual(expectedImagesPath + "begroeidterreindeelLegend_expected.png", result, testInfo);
   }
 
+  @DisabledUntil(date = "2025-04-03", reason = "PDOK WMS service is misconfigured, see issue HTM-1451")
+  @Issue("https://b3partners.atlassian.net/browse/HTM-1451")
   @Test
   @WithMockUser(username = "user")
   void test_proxied_legend_from_capabilities2(TestInfo testInfo) throws Exception {


### PR DESCRIPTION
[![HTM-1451](https://badgen.net/badge/JIRA/HTM-1451/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1451) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

disabled until 2025-04-03, the capabilities document specifies a legend image that does not exist

[HTM-1451]: https://b3partners.atlassian.net/browse/HTM-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ