### PR TITLE
HTM-1477: update Spring Boot parent (includes Spring Security) to resolve CVE-2025-22228

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <flyway.version>10.22.0</flyway.version>
         <hamcrest.version>3.0</hamcrest.version>
         <hibernate.version>6.6.11.Final</hibernate.version>
-        <!-- <jackson-bom.version>2.18.2</jackson-bom.version> -->
+        <jackson-bom.version>2.18.3</jackson-bom.version>
         <json-smart.version>2.5.2</json-smart.version>
         <junit-jupiter.version>5.12.1</junit-jupiter.version>
         <logback.version>1.5.14</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.4.4</version>
     </parent>
     <groupId>org.tailormap</groupId>
     <artifactId>tailormap-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ SPDX-License-Identifier: MIT
         <junit-jupiter.version>5.12.1</junit-jupiter.version>
         <logback.version>1.5.14</logback.version>
         <micrometer.version>1.14.5</micrometer.version>
-        <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>12.10.0.jre11</mssql-jdbc.version>
         <oracle-database.version>23.7.0.25.01</oracle-database.version>
         <postgresql.version>42.7.5</postgresql.version>
         <!-- <spring-data-bom.version>2024.0.6</spring-data-bom.version> -->

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ SPDX-License-Identifier: MIT
         <json-smart.version>2.5.2</json-smart.version>
         <junit-jupiter.version>5.12.1</junit-jupiter.version>
         <logback.version>1.5.14</logback.version>
-        <micrometer.version>1.14.4</micrometer.version>
+        <micrometer.version>1.14.5</micrometer.version>
         <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
         <oracle-database.version>23.7.0.25.01</oracle-database.version>
         <postgresql.version>42.7.5</postgresql.version>


### PR DESCRIPTION
[![HTM-1477](https://badgen.net/badge/JIRA/HTM-1477/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1477) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

fixes:
- https://github.com/Tailormap/tailormap-api/security/dependabot/12
- https://github.com/Tailormap/tailormap-api/security/code-scanning/383
- https://github.com/Tailormap/tailormap-api/security/code-scanning/382
- https://github.com/Tailormap/tailormap-api/security/code-scanning/381



[HTM-1477]: https://b3partners.atlassian.net/browse/HTM-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ