### PR TITLE
Bump io.fabric8:docker-maven-plugin from 0.45.1 to 0.46.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
     </parent>
     <groupId>org.tailormap</groupId>
     <artifactId>tailormap-api</artifactId>
-    <version>11.5.1-SNAPSHOT</version>
+    <version>12.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Tailormap API</name>
     <description>Tailormap API provides the backend for Tailormap</description>
@@ -704,7 +704,7 @@ SPDX-License-Identifier: MIT
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.45.1</version>
+                    <version>0.46.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>
@@ -1663,6 +1663,7 @@ SPDX-License-Identifier: MIT
                         <!-- deploy latest and versioned tag -->
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
+                        <extensions>true</extensions>
                         <configuration>
                             <verbose>true</verbose>
                             <imagePullPolicy>Always</imagePullPolicy>


### PR DESCRIPTION
see https://github.com/fabric8io/docker-maven-plugin/releases/tag/v0.46.0

Also bump our project version to [12.0.0-SNAPSHOT](https://b3partners.atlassian.net/projects/HTM/versions/10468/tab/release-report-all-issues) as that is what we're working on