### PR TITLE
Add URL to GeoServiceSummary

### DIFF
--- a/src/main/java/org/tailormap/api/persistence/projections/GeoServiceSummary.java
+++ b/src/main/java/org/tailormap/api/persistence/projections/GeoServiceSummary.java
@@ -29,4 +29,6 @@ public interface GeoServiceSummary {
   GeoServiceSettings getSettings();
 
   List<AuthorizationRule> getAuthorizationRules();
+
+  String getUrl();
 }


### PR DESCRIPTION
Needed for [HTM-1516](https://b3partners.atlassian.net/browse/HTM-1516) to check whether services with service type set to auto are geoserver.

[HTM-1516]: https://b3partners.atlassian.net/browse/HTM-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ