### PR TITLE
some fixes for "Workflow does not contain permissions"

### DIFF
--- a/.github/workflows/macos-maven.yml
+++ b/.github/workflows/macos-maven.yml
@@ -1,5 +1,8 @@
 name: MacOS Maven build
 
+permissions:
+  contents: read
+
 env:
   MAVEN_OPTS: -Djava.awt.headless=true
   MAVEN_VERSION: '3.9.9'

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -3,6 +3,9 @@ name: 'REUSE Compliance Check'
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 'Check compliance'

--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -265,6 +265,8 @@ jobs:
     if: ${{ always() }}
     needs: [ build, publish, postgresql-test ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/Tailormap/tailormap-api/security/code-scanning/394](https://github.com/Tailormap/tailormap-api/security/code-scanning/394)

To fix the issue, we will add a `permissions` block to the `cleanup` job in the workflow file. Since the `cleanup` job only performs Maven cache cleanup and does not interact with the repository or other GitHub resources, we can set the permissions to `contents: read` as a minimal starting point. This ensures that the job has the least privileges required to execute.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._