### PR TITLE
Update geotools.version to v33.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ SPDX-License-Identifier: MIT
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <project.build.outputTimestamp>2025-03-21T11:33:29Z</project.build.outputTimestamp>
-        <geotools.version>33.0</geotools.version>
+        <geotools.version>33.1</geotools.version>
         <jts.version>1.20.0</jts.version>
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
         <spring.boot.version>${project.parent.version}</spring.boot.version>


### PR DESCRIPTION
### Release Notes

<details>
<summary>geotools/geotools</summary>

### [`v33.1`](https://redirect.github.com/geotools/geotools/compare/33.0...33.1)

[Compare Source](https://redirect.github.com/geotools/geotools/compare/33.0...33.1)

</details>