### PR TITLE
HTM-1542: Update Spring Boot and other dependencies

### DIFF
--- a/build/qa/owasp-suppression.xml
+++ b/build/qa/owasp-suppression.xml
@@ -43,4 +43,11 @@ SPDX-License-Identifier: MIT
    ]]></notes>
         <cve>CVE-2024-6763</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file names: http2-common-10.0.24.jar
+   We have Jetty dependencies because SolrJ uses the Jetty http classes, but this is for the server
+   ]]></notes>
+        <cve>CVE-2025-1948</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -604,11 +604,6 @@ SPDX-License-Identifier: MIT
     </dependencies>
     <repositories>
         <repository>
-            <id>B3Partners</id>
-            <name>Releases hosted by B3Partners</name>
-            <url>https://repo.b3p.nl/nexus/repository/public/</url>
-        </repository>
-        <repository>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ SPDX-License-Identifier: MIT
         <junit-jupiter.version>5.12.2</junit-jupiter.version>
         <micrometer.version>1.14.6</micrometer.version>
         <mssql-jdbc.version>12.10.0.jre11</mssql-jdbc.version>
-        <oracle-database.version>23.7.0.25.01</oracle-database.version>
+        <oracle-database.version>23.8.0.25.04</oracle-database.version>
         <postgresql.version>42.7.5</postgresql.version>
         <!-- <spring-data-bom.version>2024.0.6</spring-data-bom.version> -->
         <!-- <spring-hateoas.version>2.3.3</spring-hateoas.version> -->

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@ SPDX-License-Identifier: MIT
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.2.31</version>
+            <version>2.2.32</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <hamcrest.version>3.0</hamcrest.version>
         <hibernate.version>6.6.15.Final</hibernate.version>
         <junit-jupiter.version>5.12.2</junit-jupiter.version>
-        <micrometer.version>1.14.6</micrometer.version>
+        <micrometer.version>1.15.0</micrometer.version>
         <mssql-jdbc.version>12.10.0.jre11</mssql-jdbc.version>
         <oracle-database.version>23.8.0.25.04</oracle-database.version>
         <postgresql.version>42.7.5</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
+        <version>3.4.6</version>
     </parent>
     <groupId>org.tailormap</groupId>
     <artifactId>tailormap-api</artifactId>


### PR DESCRIPTION
[![HTM-1542](https://badgen.net/badge/JIRA/HTM-1542/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1542) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- [x] Bump `org.springframework.boot:spring-boot-starter-parent` from 3.4.5 to 3.4.6 (resolves CVE-2025-22233, CVE-2025-41232)
  - Jackson 2.18.4
  - Spring Security 6.4.6
  - Spring Framework 6.2.7
  - ... etc
- [x] Bump `com.oracle.database.jdbc:ojdbc11` from 23.7.0.25.01 to 23.8.0.25.04
- [x] Bump `micrometer.version` from 1.14.6 to 1.15.0
- [x] Bump io.swagger.core.v3:swagger-annotations from 2.2.31 to 2.2.32
- [x] Remove B3Partners repository
- [x] Suppress false positive CVE-2025-1948

Fixes https://github.com/Tailormap/tailormap-api/security/code-scanning/395 and https://github.com/Tailormap/tailormap-api/security/code-scanning/387

[HTM-1542]: https://b3partners.atlassian.net/browse/HTM-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ