### PR TITLE
Allow XML entities to be resolved in nested JARs which is checked since GeoTools 33.1

### DIFF
--- a/src/main/java/org/tailormap/api/geotools/PreventLocalAllowNestedJarEntityResolver.java
+++ b/src/main/java/org/tailormap/api/geotools/PreventLocalAllowNestedJarEntityResolver.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.tailormap.api.geotools;
+
+import java.io.IOException;
+import org.geotools.util.PreventLocalEntityResolver;
+import org.xml.sax.SAXException;
+
+/**
+ * An entity resolver that allows nested JAR files used in Spring Boot using the jar:nested: protocol to be resolved,
+ * specifically for schemas that are packed inside JAR files.
+ */
+public class PreventLocalAllowNestedJarEntityResolver extends PreventLocalEntityResolver {
+  public static final PreventLocalAllowNestedJarEntityResolver INSTANCE =
+      new PreventLocalAllowNestedJarEntityResolver();
+
+  @Override
+  public org.xml.sax.InputSource resolveEntity(String publicId, String systemId) throws IOException, SAXException {
+    if (systemId != null && systemId.matches("(?i)jar:nested:[^?#;]*\\.xsd")) {
+      return null;
+    }
+    return super.resolveEntity(publicId, systemId);
+  }
+}

--- a/src/main/java/org/tailormap/api/geotools/featuresources/WFSFeatureSourceHelper.java
+++ b/src/main/java/org/tailormap/api/geotools/featuresources/WFSFeatureSourceHelper.java
@@ -16,6 +16,7 @@ import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.internal.FeatureTypeInfo;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.tailormap.api.geotools.PreventLocalAllowNestedJarEntityResolver;
 import org.tailormap.api.geotools.wfs.SimpleWFSHelper;
 import org.tailormap.api.persistence.TMFeatureSource;
 import org.tailormap.api.persistence.TMFeatureType;
@@ -27,6 +28,8 @@ public class WFSFeatureSourceHelper extends FeatureSourceHelper {
   @Override
   public DataStore createDataStore(TMFeatureSource tmfs, Integer timeout) throws IOException {
     Map<String, Object> params = new HashMap<>();
+    params.put(WFSDataStoreFactory.ENTITY_RESOLVER.key, PreventLocalAllowNestedJarEntityResolver.INSTANCE);
+
     if (timeout != null) {
       params.put(WFSDataStoreFactory.TIMEOUT.key, timeout);
     }


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOT-7774

Fixes the exception:

```
Caused by: org.geotools.api.data.DataSourceException: Error parsing feature type for ....
	at org.geotools.data.wfs.internal.parsers.EmfAppSchemaParser.parseFeatureType(EmfAppSchemaParser.java:290) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.internal.parsers.EmfAppSchemaParser.parse(EmfAppSchemaParser.java:218) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.internal.DescribeFeatureTypeResponse.<init>(DescribeFeatureTypeResponse.java:74) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.internal.parsers.DescribeFeatureTypeResponseFactory.createResponse(DescribeFeatureTypeResponseFactory.java:75) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.internal.WFSRequest.createResponse(WFSRequest.java:209) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.internal.WFSRequest.createResponse(WFSRequest.java:36) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.ows.AbstractOpenWebService.internalIssueRequest(AbstractOpenWebService.java:447) ~[gt-main-33.1.jar!/:na]
	at org.geotools.data.wfs.internal.WFSClient.internalIssueRequest(WFSClient.java:322) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.internal.WFSClient.issueRequest(WFSClient.java:408) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.WFSDataStore.getRemoteFeatureType(WFSDataStore.java:204) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.WFSDataStore.getRemoteSimpleFeatureType(WFSDataStore.java:265) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.WFSFeatureSource.buildFeatureType(WFSFeatureSource.java:374) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.wfs.WFSFeatureStore.buildFeatureType(WFSFeatureStore.java:105) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.data.store.ContentFeatureSource.getAbsoluteSchema(ContentFeatureSource.java:336) ~[gt-main-33.1.jar!/:na]
	... 203 common frames omitted
Caused by: java.lang.RuntimeException: org.xml.sax.SAXException: Entity resolution disallowed for jar:nested:/home/spring/tailormap-api.jar/!BOOT-INF/lib/gt-xsd-gml3-33.1.jar!/org/geotools/gml3/gml.xsd
	at org.geotools.xsd.Schemas.findSchemas(Schemas.java:161) ~[gt-xsd-core-33.1.jar!/:na]
	at org.geotools.data.wfs.internal.parsers.EmfAppSchemaParser.parseFeatureType(EmfAppSchemaParser.java:288) ~[gt-wfs-ng-33.1.jar!/:na]
	... 216 common frames omitted
Caused by: org.xml.sax.SAXException: Entity resolution disallowed for jar:nested:/home/spring/tailormap-api.jar/!BOOT-INF/lib/gt-xsd-gml3-33.1.jar!/org/geotools/gml3/gml.xsd
	at org.geotools.util.PreventLocalEntityResolver.resolveEntity(PreventLocalEntityResolver.java:106) ~[gt-metadata-33.1.jar!/:na]
	at org.geotools.util.PreventLocalEntityResolver.resolveEntity(PreventLocalEntityResolver.java:67) ~[gt-metadata-33.1.jar!/:na]
	at org.geotools.data.wfs.internal.DescribeFeatureTypeResponse$TempEntityResolver.resolveEntity(DescribeFeatureTypeResponse.java:149) ~[gt-wfs-ng-33.1.jar!/:na]
	at org.geotools.xsd.Schemas.findSchemas(Schemas.java:159) ~[gt-xsd-core-33.1.jar!/:na]
	... 217 common frames omitted
```