### PR TITLE
HTM-1569: Bump postgresql.version from 42.7.6 to 42.7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@ SPDX-License-Identifier: MIT
         <!-- <micrometer.version>1.15.0</micrometer.version>-->
         <mssql-jdbc.version>12.10.0.jre11</mssql-jdbc.version>
         <oracle-database.version>23.8.0.25.04</oracle-database.version>
-        <postgresql.version>42.7.6</postgresql.version>
+        <postgresql.version>42.7.7</postgresql.version>
         <!-- <spring-data-bom.version>2024.0.6</spring-data-bom.version>-->
         <!-- <spring-hateoas.version>2.3.3</spring-hateoas.version>-->
         <!-- <spring-security.version>6.3.4</spring-security.version>-->


### PR DESCRIPTION
[![HTM-1569](https://badgen.net/badge/JIRA/HTM-1569/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1569) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

resolves https://github.com/Tailormap/tailormap-api/security/dependabot/14 / CVE-2025-49146

[HTM-1569]: https://b3partners.atlassian.net/browse/HTM-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ