### PR TITLE
Assorted dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@ SPDX-License-Identifier: MIT
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <flyway.version>11.10.4</flyway.version>
         <!-- <hamcrest.version>3.0</hamcrest.version>-->
-        <hibernate.version>6.6.24.Final</hibernate.version>
+        <hibernate.version>6.6.25.Final</hibernate.version>
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <!-- <micrometer.version>1.15.0</micrometer.version>-->
         <mssql-jdbc.version>12.10.1.jre11</mssql-jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,15 @@ SPDX-License-Identifier: MIT
                 <artifactId>modernizer-maven-annotations</artifactId>
                 <version>${modernizer-maven-plugin.version}</version>
             </dependency>
+            <dependency>
+                <!--
+                Override for CVE-2025-53864, see https://github.com/Tailormap/tailormap-api/security/dependabot/20
+                Should probably be removed when Spring Security / Spring Boot is updated to 6.5.3/3.5.5 or later, check the dependency tree
+                -->
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>9.37.4</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ SPDX-License-Identifier: MIT
         <!-- <hamcrest.version>3.0</hamcrest.version>-->
         <hibernate.version>6.6.25.Final</hibernate.version>
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
-        <!-- <micrometer.version>1.15.0</micrometer.version>-->
+        <micrometer.version>1.15.3</micrometer.version>
         <mssql-jdbc.version>13.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>23.9.0.25.07</oracle-database.version>
         <postgresql.version>42.7.7</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -195,11 +195,6 @@ SPDX-License-Identifier: MIT
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.gaul</groupId>
-                <artifactId>modernizer-maven-annotations</artifactId>
-                <version>${modernizer-maven-plugin.version}</version>
-            </dependency>
-            <dependency>
                 <!--
                 Override for CVE-2025-53864, see https://github.com/Tailormap/tailormap-api/security/dependabot/20
                 Should probably be removed when Spring Security / Spring Boot is updated to 6.5.3/3.5.5 or later, check the dependency tree
@@ -207,6 +202,11 @@ SPDX-License-Identifier: MIT
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.37.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-annotations</artifactId>
+                <version>${modernizer-maven-plugin.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ SPDX-License-Identifier: MIT
         <hibernate.version>6.6.25.Final</hibernate.version>
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <!-- <micrometer.version>1.15.0</micrometer.version>-->
-        <mssql-jdbc.version>12.10.1.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>13.2.0.jre11</mssql-jdbc.version>
         <oracle-database.version>23.9.0.25.07</oracle-database.version>
         <postgresql.version>42.7.7</postgresql.version>
         <!-- <spring-data-bom.version>2024.0.6</spring-data-bom.version>-->


### PR DESCRIPTION
- Override com.nimbusds:nimbus-jose-jwt to 9.37.4 for CVE-2025-53864 (https://github.com/Tailormap/tailormap-api/security/dependabot/20) / https://github.com/Tailormap/tailormap-api/security/code-scanning/407)
- Bump hibernate.version from 6.6.24.Final to 6.6.25.Final
- Bump mssql-jdbc.version from 12.10.1.jre11 to 13.2.0.jre11
- Bump micrometer.version from 1.15.2 to 1.15.3