### PR TITLE
Bump Solr jetty.version override from 10.0.24 to 10.0.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@ SPDX-License-Identifier: MIT
         Caused by: java.lang.NoClassDefFoundError: org/eclipse/jetty/client/util/InputStreamResponseListener 
         because Solr uses http libraries from the Jetty project
         -->
-        <jetty.version>10.0.24</jetty.version>
+        <jetty.version>10.0.26</jetty.version>
         <solr.version>9.9.0</solr.version>
         <!--
         Spring Boot version overrides.


### PR DESCRIPTION
resolves https://github.com/Tailormap/tailormap-api/security/dependabot/22