### PR TITLE
add substring option to checkbox filter

### DIFF
--- a/src/main/resources/openapi/common-schemas.yaml
+++ b/src/main/resources/openapi/common-schemas.yaml
@@ -389,7 +389,7 @@ components:
                   default: true
                 alias:
                   type: string
-                useAsLikeSubstringFilter:
+                useAsIlikeSubstringFilter:
                   description: 'Use this value as a separate substring filter using the ILIKE condition'
                   type: boolean
                   default: false


### PR DESCRIPTION
Add useAsLikeSubstringFilter option to attributeValueSettings for checkbox filters to indicate this value will be used as a separate filter using the 'ILIKE" condition. This is needed for [EO-562](https://b3partners.atlassian.net/browse/EO-562)

[EO-562]: https://b3partners.atlassian.net/browse/EO-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ