### PR TITLE
Allow actuator access from internal networks and localhost

### DIFF
--- a/build/ci/compose-config-files/prometheus.yaml
+++ b/build/ci/compose-config-files/prometheus.yaml
@@ -10,9 +10,6 @@ global:
 scrape_configs:
   - job_name: 'tailormap-api-snapshot'
     scheme: 'http'
-    basic_auth:
-      password: 'tm-admin'
-      username: 'tm-admin'
     static_configs:
       - targets:
           - 'host.docker.internal:8080'

--- a/src/test/java/org/tailormap/api/security/ActuatorSecurityConfigurationIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/security/ActuatorSecurityConfigurationIntegrationTest.java
@@ -66,11 +66,13 @@ class ActuatorSecurityConfigurationIntegrationTest {
         .andExpect(content().json("{\"status\":\"UP\"}"));
   }
 
+  @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
   private static final RequestPostProcessor internetRequest = (MockHttpServletRequest request) -> {
     request.setRemoteAddr("8.8.8.8");
     return request;
   };
 
+  @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
   private static final RequestPostProcessor localNetworkRequest = (MockHttpServletRequest request) -> {
     request.setRemoteAddr("172.1.1.1");
     return request;

--- a/src/test/java/org/tailormap/api/security/ActuatorSecurityConfigurationIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/security/ActuatorSecurityConfigurationIntegrationTest.java
@@ -17,9 +17,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.tailormap.api.annotation.PostgresIntegrationTest;
 import org.tailormap.api.persistence.Group;
 
@@ -64,18 +66,41 @@ class ActuatorSecurityConfigurationIntegrationTest {
         .andExpect(content().json("{\"status\":\"UP\"}"));
   }
 
+  private static final RequestPostProcessor internetRequest = (MockHttpServletRequest request) -> {
+    request.setRemoteAddr("8.8.8.8");
+    return request;
+  };
+
+  private static final RequestPostProcessor localNetworkRequest = (MockHttpServletRequest request) -> {
+    request.setRemoteAddr("172.1.1.1");
+    return request;
+  };
+
   @Test
-  void testUnAuthenticatedPrometheus() throws Exception {
-    mockMvc.perform(get(basePath + "/prometheus").accept(MediaType.TEXT_PLAIN))
+  void testUnAuthenticatedPrometheusFromInternet() throws Exception {
+    mockMvc.perform(get(basePath + "/prometheus")
+            .accept(MediaType.TEXT_PLAIN)
+            .with(internetRequest))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void testUnAuthenticatedPrometheusFromLocalNetwork() throws Exception {
+    mockMvc.perform(get(basePath + "/prometheus")
+            .accept(MediaType.TEXT_PLAIN)
+            .with(localNetworkRequest))
+        .andExpect(status().isOk())
+        .andExpect(content().string(startsWith("# HELP")));
   }
 
   @Test
   @WithMockUser(
       username = "tm-admin",
       authorities = {Group.ADMIN})
-  void testAuthenticatedPrometheus() throws Exception {
-    mockMvc.perform(get(basePath + "/prometheus").accept(MediaType.TEXT_PLAIN))
+  void testAuthenticatedPrometheusFromInternet() throws Exception {
+    mockMvc.perform(get(basePath + "/prometheus")
+            .accept(MediaType.TEXT_PLAIN)
+            .with(internetRequest))
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
         .andExpect(content().string(startsWith("# HELP")))


### PR DESCRIPTION
This allows prometheus to scrape without a password.