### PR TITLE
HTM-1600: Cleanup the application and application layer metrics when an application is deleted

### DIFF
--- a/src/main/java/org/tailormap/api/repository/events/ApplicationEventHandler.java
+++ b/src/main/java/org/tailormap/api/repository/events/ApplicationEventHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.repository.events;
+
+import static org.tailormap.api.prometheus.TagNames.METRICS_APP_ID_TAG;
+import static org.tailormap.api.prometheus.TagNames.METRICS_APP_REQUEST_COUNTER_NAME;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.rest.core.annotation.HandleAfterDelete;
+import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
+import org.springframework.stereotype.Component;
+import org.tailormap.api.persistence.Application;
+import org.tailormap.api.prometheus.PrometheusService;
+
+@Component
+@RepositoryEventHandler
+public class ApplicationEventHandler {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final PrometheusService prometheusService;
+
+  @Value("${tailormap-api.allowed-metrics}")
+  private Set<String> allowedMetrics;
+
+  public ApplicationEventHandler(PrometheusService prometheusService) {
+    this.prometheusService = prometheusService;
+  }
+
+  /**
+   * Handle after delete. Delete any associated task.
+   *
+   * @param application the application that was deleted
+   */
+  @HandleAfterDelete
+  public void afterDeleteApplicationEventHandler(Application application) {
+    logger.debug("Application '{}' (id: {}) was deleted.", application.getName(), application.getId());
+    if (prometheusService.isPrometheusAvailable()) {
+      // cleanup any metrics from Prometheus or other systems if needed
+      ArrayList<String> metricsToDelete = new ArrayList<>();
+      // application metrics
+      metricsToDelete.add(METRICS_APP_REQUEST_COUNTER_NAME + "_total{" + METRICS_APP_ID_TAG + "=\""
+          + application.getId().toString() + "\"}");
+      // application layer metrics
+      for (String metricName : allowedMetrics) {
+        metricsToDelete.add(metricName + "_total{" + METRICS_APP_ID_TAG + "=\""
+            + application.getId().toString() + "\"}");
+      }
+      try {
+        logger.info(
+            "Cleaning up all metrics for deleted application with id: {}, (name: '{}')",
+            application.getId(),
+            application.getName());
+        logger.debug("Deleting metrics matching: {}", metricsToDelete);
+        prometheusService.deleteMetric(metricsToDelete.toArray(new String[metricsToDelete.size()]));
+      } catch (IOException e) {
+        logger.error("Error cleaning up metrics for deleted application with id: {}", application.getId(), e);
+      }
+    }
+  }
+}

--- a/src/test/java/org/tailormap/api/prometheus/PrometheusServiceIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/prometheus/PrometheusServiceIntegrationTest.java
@@ -28,7 +28,7 @@ import org.tailormap.api.annotation.PostgresIntegrationTest;
 @Stopwatch
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisableIfTestFails
-@Order(Integer.MAX_VALUE)
+@Order(Integer.MAX_VALUE - 1)
 class PrometheusServiceIntegrationTest {
   @Autowired
   private PrometheusService prometheusService;
@@ -107,7 +107,6 @@ label_replace(floor(time()-max_over_time(timestamp(changes(tailormap_app_request
     final String delete = "scrape_samples_scraped";
     try {
       prometheusService.deleteMetric(delete);
-
     } catch (Exception e) {
       fail("Delete failed: " + e.getMessage());
     }

--- a/src/test/java/org/tailormap/api/repository/events/ApplicationEventHandlerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/repository/events/ApplicationEventHandlerIntegrationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.repository.events;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.tailormap.api.annotation.PostgresIntegrationTest;
+import org.tailormap.api.persistence.Application;
+import org.tailormap.api.persistence.Group;
+import org.tailormap.api.prometheus.PrometheusService;
+import org.tailormap.api.repository.ApplicationRepository;
+
+@Transactional
+@Order(Integer.MAX_VALUE)
+@AutoConfigureMockMvc
+@PostgresIntegrationTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApplicationEventHandlerIntegrationTest {
+  @Autowired
+  private ApplicationEventHandler applicationEventHandler;
+
+  @Autowired
+  private ApplicationRepository applicationRepository;
+
+  @Autowired
+  private PrometheusService prometheusService;
+
+  @Autowired
+  private WebApplicationContext context;
+
+  private MockMvc mockMvc;
+
+  @Value("${tailormap-api.admin.base-path}")
+  private String adminBasePath;
+
+  @BeforeAll
+  void initialize() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+  }
+
+  @Test
+  @WithMockUser(
+      username = "tm-admin",
+      authorities = {Group.ADMIN})
+  void test() throws Exception {
+    Application application = applicationRepository.findByName("default");
+    assertEquals(1, application.getId(), "default application should have id 1");
+    assertTrue(prometheusService.isPrometheusAvailable());
+
+    // trigger the delete event handler
+    applicationEventHandler.afterDeleteApplicationEventHandler(application);
+
+    mockMvc.perform(get(adminBasePath + "/graph/applications"))
+        .andExpect(status().isOk())
+        .andDo(print())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.applications").isArray())
+        .andExpect(jsonPath("$.applications[0].appId").value("5"));
+  }
+}


### PR DESCRIPTION
[![HTM-1600](https://badgen.net/badge/JIRA/HTM-1600/pink?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1600) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Use the `@HandleAfterDelete` repository event to handle cleanup

[HTM-1600]: https://b3partners.atlassian.net/browse/HTM-1600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ