### PR TITLE
Reduce log output when Prometheus is not available

### DIFF
--- a/src/main/java/org/tailormap/api/controller/admin/PrometheusDataController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/PrometheusDataController.java
@@ -97,7 +97,7 @@ public class PrometheusDataController implements TagNames, InitializingBean {
         logger.error("Error initializing Prometheus ping task", e);
       }
     } else {
-      logger.warn("Prometheus is not available, /graph/ endpoint will not be functional.");
+      logger.info("Prometheus is not available, /graph/ endpoint will not be functional.");
     }
   }
 

--- a/src/main/java/org/tailormap/api/prometheus/PrometheusService.java
+++ b/src/main/java/org/tailormap/api/prometheus/PrometheusService.java
@@ -53,7 +53,7 @@ public class PrometheusService {
         return false;
       }
     } catch (Exception e) {
-      logger.warn("Error checking Prometheus availability", e);
+      logger.debug("Error checking Prometheus availability", e);
       return false;
     }
   }


### PR DESCRIPTION
It's a normal use case to deploy without Prometheus so no warnings or stack traces in that case.