### PR TITLE
Remove spotify fmt-maven-plugin from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -700,11 +700,6 @@ SPDX-License-Identifier: MIT
                     <version>4.0.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>com.spotify.fmt</groupId>
-                    <artifactId>fmt-maven-plugin</artifactId>
-                    <version>2.28</version>
-                </plugin>
-                <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>0.46.0</version>


### PR DESCRIPTION
Removed the fmt-maven-plugin from the pom.xml file.