### PR TITLE
Apply the OpenRewrite Java 17 rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,10 +292,6 @@ SPDX-License-Identifier: MIT
             <version>2.2.37</version>
         </dependency>
         <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
@@ -553,6 +549,11 @@ SPDX-License-Identifier: MIT
             <artifactId>webjars-locator-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.romankh3</groupId>
             <artifactId>image-comparison</artifactId>
             <version>4.4.0</version>
@@ -728,6 +729,23 @@ SPDX-License-Identifier: MIT
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>6.18.0</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>org.openrewrite.java.migrate.UpgradeToJava17</recipe>
+                    </activeRecipes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-migrate-java</artifactId>
+                        <version>3.17.1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <configuration>

--- a/src/test/java/org/tailormap/api/controller/admin/FeatureSourceAdminControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/admin/FeatureSourceAdminControllerIntegrationTest.java
@@ -50,13 +50,13 @@ class FeatureSourceAdminControllerIntegrationTest {
 
     DriverManagerDataSource dataSource = new DriverManagerDataSource();
     dataSource.setDriverClassName("org.postgresql.Driver");
-    dataSource.setUrl(String.format("jdbc:postgresql://%s:%s/%s", host, port, database));
+    dataSource.setUrl("jdbc:postgresql://%s:%s/%s".formatted(host, port, database));
     dataSource.setUsername(user);
     dataSource.setPassword(password);
     JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
     jdbcTemplate.execute("drop table if exists test");
 
-    String featureSourcePOSTBody = String.format(
+    String featureSourcePOSTBody =
         """
 {
 "title": "My Test Source",
@@ -75,8 +75,8 @@ class FeatureSourceAdminControllerIntegrationTest {
 "username": "%s",
 "password": "%s"
 }
-}""",
-        port, host, database, user, password);
+}"""
+            .formatted(port, host, database, user, password);
 
     MvcResult result = mockMvc.perform(post(adminBasePath + "/feature-sources")
             .contentType(MediaType.APPLICATION_JSON)
@@ -92,8 +92,7 @@ class FeatureSourceAdminControllerIntegrationTest {
     try {
       jdbcTemplate.execute("create table test(id serial primary key)");
 
-      mockMvc.perform(post(
-              adminBasePath + String.format("/feature-sources/%s/refresh-capabilities", featureSourceId)))
+      mockMvc.perform(post(adminBasePath + "/feature-sources/%s/refresh-capabilities".formatted(featureSourceId)))
           .andExpect(status().isFound())
           .andExpect(header().string("Location", equalTo(selfLink)));
 
@@ -111,8 +110,7 @@ class FeatureSourceAdminControllerIntegrationTest {
       }
     }
 
-    mockMvc.perform(post(
-            adminBasePath + String.format("/feature-sources/%s/refresh-capabilities", featureSourceId)))
+    mockMvc.perform(post(adminBasePath + "/feature-sources/%s/refresh-capabilities".formatted(featureSourceId)))
         .andExpect(status().isFound())
         .andExpect(header().string("Location", equalTo(selfLink)));
 

--- a/src/test/java/org/tailormap/api/controller/admin/FindUploadsByHashControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/admin/FindUploadsByHashControllerIntegrationTest.java
@@ -54,15 +54,14 @@ class FindUploadsByHashControllerIntegrationTest {
         .orElseThrow(() -> new IllegalStateException(
             "Expected upload with filename 'ISO_7001_PI_PF_007.svg' not found in the database"));
 
-    String expected = String.format(
-        """
+    String expected = """
 [
 {
 "id": "%s",
 "hash": "cfb1b538761a21f8d39c0555ba9802b8af4d09a6"
 }
-]""",
-        water.getId().toString());
+]"""
+        .formatted(water.getId().toString());
 
     mockMvc.perform(post(adminBasePath + "/uploads/find-by-hash/drawing-style-image")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/org/tailormap/api/controller/admin/GeoServiceAdminControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/admin/GeoServiceAdminControllerIntegrationTest.java
@@ -112,7 +112,7 @@ class GeoServiceAdminControllerIntegrationTest {
       server.enqueue(
           new MockResponse.Builder().headers(contentType).body(body).build());
 
-      mockMvc.perform(post(adminBasePath + String.format("/geo-services/%s/refresh-capabilities", serviceId)))
+      mockMvc.perform(post(adminBasePath + "/geo-services/%s/refresh-capabilities".formatted(serviceId)))
           .andExpect(status().isFound())
           .andExpect(header().string("Location", equalTo(selfLink)));
 
@@ -169,7 +169,7 @@ class GeoServiceAdminControllerIntegrationTest {
         .andReturn();
     String serviceId = JsonPath.read(result.getResponse().getContentAsString(), "$.id");
 
-    mockMvc.perform(post(adminBasePath + String.format("/geo-services/%s/refresh-capabilities", serviceId)))
+    mockMvc.perform(post(adminBasePath + "/geo-services/%s/refresh-capabilities".formatted(serviceId)))
         .andExpect(status().isBadRequest())
         .andExpect(
             content()

--- a/src/test/java/org/tailormap/api/util/TMPasswordDeserializerTest.java
+++ b/src/test/java/org/tailormap/api/util/TMPasswordDeserializerTest.java
@@ -39,7 +39,7 @@ class TMPasswordDeserializerTest {
 
   @Test
   void testEmptyPassword() {
-    final String testJson = String.format(testJsonTemplate, "");
+    final String testJson = testJsonTemplate.formatted("");
     assertThrows(
         InvalidPasswordException.class,
         () -> this.deserializeJson(testJson),
@@ -48,7 +48,7 @@ class TMPasswordDeserializerTest {
 
   @Test
   void testWeakPassword() {
-    final String testJson = String.format(testJsonTemplate, "flamingo");
+    final String testJson = testJsonTemplate.formatted("flamingo");
     assertThrows(
         InvalidPasswordException.class,
         () -> this.deserializeJson(testJson),
@@ -57,7 +57,7 @@ class TMPasswordDeserializerTest {
 
   @Test
   void testValidPassword() throws IOException {
-    final String testJson = String.format(testJsonTemplate, "myValidSecret$@12");
+    final String testJson = testJsonTemplate.formatted("myValidSecret$@12");
     String actual = this.deserializeJson(testJson);
 
     assertNotNull(actual, "encrypted password should not be null");


### PR DESCRIPTION
using `mvn rewrite:run` after configuring as documented on https://docs.openrewrite.org/running-recipes/popular-recipe-guides/migrate-to-java-17

It seems to be only about switching `String.format(...)` to `"".formatted(...)` in some testcases