### PR TITLE
Bump maven-scm-publish-plugin from 3.2.1 to 3.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,21 @@ mvn -Pdeveloping,postgresql verify -Dspring-boot.run.profiles=dev,populate-testd
 
 ## Releasing
 
+### Prerequisites
+
+Add a `gh-pages` server to your Maven settings.xml that uses your SSH key for authentication and `git` as a username.
+For example:
+
+```xml
+<server>
+    <id>gh-pages</id>
+    <passphrase>XXXXX lots of XXXXs in my passphrase!</passphrase>
+    <privateKey>~/.ssh/id_rsa</privateKey>
+    <username>git</username>
+</server>
+```
+
+### Release procedure
 Use the regular Maven release cycle of `mvn release:prepare` followed by `mvn release:perform`. Please make sure that
 you use `tailormap-api-<VERSION>` as a tag so that the release notes are automatically created.
 For example:

--- a/pom.xml
+++ b/pom.xml
@@ -740,7 +740,7 @@ SPDX-License-Identifier: MIT
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
and update documentation.


Add a `gh-pages` server to your Maven settings.xml that uses your SSH key for authentication and `git` as a username.
For example:

```xml
<server>
    <id>gh-pages</id>
    <passphrase>XXXXX lots of XXXXs in my passphrase!</passphrase>
    <privateKey>~/.ssh/id_rsa</privateKey>
    <username>git</username>
</server>
```