### PR TITLE
⛓️‍💥 HTM-1875: update viewer API model to provide styles to viewer

### DIFF
--- a/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
@@ -93,6 +94,7 @@ import org.tailormap.api.persistence.json.PageTile;
 import org.tailormap.api.persistence.json.ServiceAuthentication;
 import org.tailormap.api.persistence.json.TailormapObjectRef;
 import org.tailormap.api.persistence.json.TileLayerHiDpiMode;
+import org.tailormap.api.persistence.json.WMSStyle;
 import org.tailormap.api.repository.ApplicationRepository;
 import org.tailormap.api.repository.CatalogRepository;
 import org.tailormap.api.repository.ConfigurationRepository;
@@ -814,7 +816,21 @@ https://postgis.net/brand.svg""")
                           .featureSourceId(featureSources
                               .get("postgis")
                               .getId())
-                          .featureTypeName("begroeidterreindeel")),
+                          .featureTypeName("begroeidterreindeel"))
+                      .selectedStyles(
+                          List.of(
+                              new WMSStyle(
+                                  "begroeidterreindeel",
+                                  "Visualisatie van de begroeide terreindelen",
+                                  "Deze stylesheet bevat de regels voor de visualisatie van het objecttype Begroeid Terreindeel",
+                                  URI.create(
+                                      "https://snapshot.tailormap.nl/geoserver/ows?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=test%3Apostgis_begroeidterreindeel")),
+                              new WMSStyle(
+                                  "purple_polygon",
+                                  "purple_polygon",
+                                  null,
+                                  URI.create(
+                                      "https://snapshot.tailormap.nl/geoserver/ows?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&width=20&height=20&layer=test%3Apostgis_begroeidterreindeel&style=purple_polygon")))),
                   "postgis:bak",
                   new GeoServiceLayerSettings()
                       .featureType(new FeatureTypeRef()

--- a/src/main/java/org/tailormap/api/persistence/helper/ApplicationHelper.java
+++ b/src/main/java/org/tailormap/api/persistence/helper/ApplicationHelper.java
@@ -448,7 +448,10 @@ public class ApplicationHelper {
           .description(description)
           .webMercatorAvailable(webMercatorAvailable)
           .tileset3dStyle(appLayerSettings.getTileset3dStyle())
-          .hiddenFunctionality(appLayerSettings.getHiddenFunctionality()));
+          .hiddenFunctionality(appLayerSettings.getHiddenFunctionality())
+          // TODO / HTM-1884: check if there are styles configured in the app layer settings and use those
+          //   instead of the service layer styles
+          .styles(serviceLayerSettings.getSelectedStyles()));
 
       return true;
     }

--- a/src/main/java/org/tailormap/api/persistence/helper/GeoServiceHelper.java
+++ b/src/main/java/org/tailormap/api/persistence/helper/GeoServiceHelper.java
@@ -273,10 +273,10 @@ public class GeoServiceHelper {
                       .map(Objects::toString)
                       .orElse(null));
               try {
-                List<?> legendURLs = gtStyle.getLegendURLs();
+                List<?> legendUrls = gtStyle.getLegendURLs();
                 // GeoTools will replace invalid URLs with null in legendURLs
-                if (legendURLs != null && !legendURLs.isEmpty() && legendURLs.getFirst() != null) {
-                  style.legendURL(new URI((String) legendURLs.getFirst()));
+                if (legendUrls != null && !legendUrls.isEmpty() && legendUrls.getFirst() != null) {
+                  style.legendUrl(new URI((String) legendUrls.getFirst()));
                 }
               } catch (URISyntaxException ignored) {
                 // Won't occur because GeoTools would have already returned null on
@@ -510,13 +510,13 @@ public class GeoServiceHelper {
       // this layer, if any
       return serviceLayer.getStyles().stream()
           .findFirst()
-          .map(WMSStyle::getLegendURL)
+          .map(WMSStyle::getLegendUrl)
           .orElse(null);
     }
 
     final List<WMSStyle> allOurLayersStyles = serviceLayer.getStyles();
     if (allOurLayersStyles.size() == 1) {
-      return allOurLayersStyles.getFirst().getLegendURL();
+      return allOurLayersStyles.getFirst().getLegendUrl();
     }
     // remove the styles from all the other layer(s) from the list of all our layers styles
     service.getLayers().stream()
@@ -525,7 +525,7 @@ public class GeoServiceHelper {
 
     return allOurLayersStyles.stream()
         .findFirst()
-        .map(WMSStyle::getLegendURL)
+        .map(WMSStyle::getLegendUrl)
         .orElse(null);
   }
 }

--- a/src/main/resources/openapi/common-schemas.yaml
+++ b/src/main/resources/openapi/common-schemas.yaml
@@ -184,7 +184,7 @@ components:
           type: string
         abstractText:
           type: string
-        legendURL:
+        legendUrl:
           type: string
           format: uri
 

--- a/src/main/resources/openapi/viewer-schemas.yaml
+++ b/src/main/resources/openapi/viewer-schemas.yaml
@@ -165,6 +165,12 @@ components:
           nullable: true
         hiddenFunctionality:
           $ref: './common-schemas.yaml#/components/schemas/HiddenLayerFunctionality'
+        styles:
+          description: 'Configured WMS styles for this layer, if any.'
+          type: array
+          items:
+            $ref: './common-schemas.yaml#/components/schemas/WMSStyle'
+
 
     LayerTreeNode:
       description: Grouping of layers in a tree structure.

--- a/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -195,16 +196,26 @@ class ViewerControllerIntegrationTest {
   }
 
   @Test
-  void should_contain_description() throws Exception {
+  void should_contain_description_and_styles() throws Exception {
     final String path = apiBasePath + "/app/default/map";
     mockMvc.perform(get(path).accept(MediaType.APPLICATION_JSON).with(setServletPath(path)))
         .andExpect(status().isOk())
+        .andDo(print())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(
             // Application layer description
             jsonPath(
                     "$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:begroeidterreindeel')].description")
-                .value(contains(startsWith("This layer shows data from https://www.postgis.net"))));
+                .value(contains(startsWith("This layer shows data from https://www.postgis.net"))))
+        .andExpect(
+            // Application layer configured styles
+            jsonPath("$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:begroeidterreindeel')].styles")
+                .isArray())
+        .andExpect(
+            // Application layer configured styles
+            jsonPath(
+                    "$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:begroeidterreindeel')].styles[1].title")
+                .value("purple_polygon"));
   }
 
   @Test

--- a/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -200,7 +199,6 @@ class ViewerControllerIntegrationTest {
     final String path = apiBasePath + "/app/default/map";
     mockMvc.perform(get(path).accept(MediaType.APPLICATION_JSON).with(setServletPath(path)))
         .andExpect(status().isOk())
-        .andDo(print())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(
             // Application layer description
@@ -211,10 +209,13 @@ class ViewerControllerIntegrationTest {
             // Application layer configured styles
             jsonPath("$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:begroeidterreindeel')].styles")
                 .isArray())
+        .andExpect(jsonPath(
+                "$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:begroeidterreindeel')].styles[1].title")
+            .value("purple_polygon"))
         .andExpect(
             // Application layer configured styles
             jsonPath(
-                    "$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:begroeidterreindeel')].styles[1].title")
+                    "$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:begroeidterreindeel')].styles[1].name")
                 .value("purple_polygon"));
   }
 


### PR DESCRIPTION
[![HTM-1875](https://img.shields.io/badge/JIRA-HTM--1875-7A54FF?logo=jira)](https://b3partners.atlassian.net/browse/HTM-1875) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

blocks: https://github.com/Tailormap/tailormap-viewer/pull/1141

Potentially breaking change is the rename of the `legendUrl` to be consistent with frontend; this should not be a probles as it was not available for use before, however to be able to select style(s) for a layer, services will need to be refreshed so that the capabilities are reloaded

[HTM-1875]: https://b3partners.atlassian.net/browse/HTM-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ