### PR TITLE
HTM-1951: Guard for NPE on GeoServiceSettings.getLayerSettings()

### DIFF
--- a/src/main/java/org/tailormap/api/persistence/GeoService.java
+++ b/src/main/java/org/tailormap/api/persistence/GeoService.java
@@ -342,7 +342,12 @@ public class GeoService extends AuditMetadata {
   }
 
   public GeoServiceLayerSettings getLayerSettings(String layerName) {
-    return getSettings().getLayerSettings().get(layerName);
+    // do a possibly superfluous null check for issue HTM-1951
+    GeoServiceLayerSettings layerSettings = null;
+    if (getSettings().getLayerSettings() != null) {
+      layerSettings = getSettings().getLayerSettings().get(layerName);
+    }
+    return layerSettings;
   }
 
   @NonNull public String getTitleWithSettingsOverrides(String layerName) {

--- a/src/main/java/org/tailormap/api/security/AuthorisationService.java
+++ b/src/main/java/org/tailormap/api/security/AuthorisationService.java
@@ -212,8 +212,12 @@ public class AuthorisationService {
       return false;
     }
 
-    GeoServiceLayerSettings layerSettings =
-        geoService.getSettings().getLayerSettings().get(layer.getName());
+    // do a possibly superfluous null check for issue HTM-1951
+    GeoServiceLayerSettings layerSettings = null;
+    if (geoService.getSettings().getLayerSettings() != null) {
+      layerSettings = geoService.getSettings().getLayerSettings().get(layer.getName());
+    }
+
     if (layerSettings != null && layerSettings.getAuthorizationRules() != null) {
       logger.trace(
           "Checking layer settings rules for GeoService '{}' and layer '{}'. \nRules: {}",


### PR DESCRIPTION
[![HTM-1951](https://badgen.net/badge/JIRA/HTM-1951/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1951) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

According to the models this should not be possible, reality is different....

```
java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because the return value of "org.tailormap.api.persistence.json.GeoServiceSettings.getLayerSettings()" is null
        at org.tailormap.api.security.AuthorisationService.userAllowedToViewGeoServiceLayer(AuthorisationService.java:216) ~[classes/:12.6.0]
        at org.tailormap.api.persistence.helper.ApplicationHelper$MapResponseLayerBuilder.findServiceLayer(ApplicationHelper.java:511) ~[classes/:12.6.0]
        at org.tailormap.api.persistence.helper.ApplicationHelper$MapResponseLayerBuilder.addAppLayerItem(ApplicationHelper.java:337) ~[classes/:12.6.0]
        at org.tailormap.api.persistence.helper.ApplicationHelper$MapResponseLayerBuilder.addAppTreeNodeItem(ApplicationHelper.java:317) ~[classes/:12.6.0]
        at org.tailormap.api.persistence.helper.ApplicationHelper$MapResponseLayerBuilder.buildOverlayLayers(ApplicationHelper.java:249) ~[classes/:12.6.0]
        at org.tailormap.api.persistence.helper.ApplicationHelper$MapResponseLayerBuilder.buildLayers(ApplicationHelper.java:227) ~[classes/:12.6.0]
        at org.tailormap.api.persistence.helper.ApplicationHelper.setLayers(ApplicationHelper.java:163) ~[classes/:12.6.0]
        at org.tailormap.api.persistence.helper.ApplicationHelper.toMapResponse(ApplicationHelper.java:138) ~[classes/:12.6.0]
``` 

[HTM-1951]: https://b3partners.atlassian.net/browse/HTM-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ