### PR TITLE
Increase max connections for postgres container, use smaller hikari pool

### DIFF
--- a/build/ci/docker-compose.yml
+++ b/build/ci/docker-compose.yml
@@ -24,6 +24,9 @@ services:
   postgres:
     container_name: postgres
     image: postgis/postgis:18-3.6
+    command:
+     - "-c"
+     - "max_connections=200"
     environment:
       TZ: Europe/Amsterdam
       POSTGRES_USER: tailormap

--- a/src/test/resources/application-postgresql.properties
+++ b/src/test/resources/application-postgresql.properties
@@ -24,6 +24,8 @@ tailormap-api.prometheus-api-appmetrics-layer-switched-on-updated=time()-max_ove
 spring.datasource.url=jdbc:postgresql:tailormap
 spring.datasource.username=tailormap
 spring.datasource.password=tailormap
+# half of the default value of 10, to prevent too many connections in integration tests
+spring.datasource.hikari.maximum-pool-size=5
 spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.use_sql_comments=true
 


### PR DESCRIPTION
Increase max connections for the "postgres" container as it can run out of connections during integration tests, also use half of the default pool size to prevent exhausting the connections.


Applies:
- more available connections on the postgres container
- smaller hikari pool
to prevent connection exhaust problems during integration testing. 

A comprehensive write-up in https://stackoverflow.com/questions/79028148/hikari-pool-is-not-shutdown-after-spring-boot-test-execution-with-test-container

Worth reading: https://commerce-engineer.rakuten.careers/entry/en/tech/0054