### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@ SPDX-License-Identifier: MIT
         <flyway.version>12.4.0</flyway.version>
         <hibernate.version>7.3.3.Final</hibernate.version>
         <jackson-2-bom.version>2.21.3</jackson-2-bom.version>
+        <jackson-bom.version>3.1.3</jackson-bom.version>
         <json-path.version>3.0.0</json-path.version>
         <junit-jupiter.version>6.0.3</junit-jupiter.version>
         <micrometer.version>1.16.5</micrometer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <commons-codec.version>1.21.0</commons-codec.version>
         <flyway.version>12.4.0</flyway.version>
         <hibernate.version>7.3.3.Final</hibernate.version>
-        <jackson-2-bom.version>2.21.2</jackson-2-bom.version>
+        <jackson-2-bom.version>2.21.3</jackson-2-bom.version>
         <json-path.version>3.0.0</json-path.version>
         <junit-jupiter.version>6.0.3</junit-jupiter.version>
         <micrometer.version>1.16.5</micrometer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ SPDX-License-Identifier: MIT
         -->
         <awaitility.version>4.3.0</awaitility.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <commons-codec.version>1.21.0</commons-codec.version>
+        <commons-codec.version>1.22.0</commons-codec.version>
         <flyway.version>12.4.0</flyway.version>
         <hibernate.version>7.3.3.Final</hibernate.version>
         <jackson-2-bom.version>2.21.3</jackson-2-bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@ SPDX-License-Identifier: MIT
         <awaitility.version>4.3.0</awaitility.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-codec.version>1.22.0</commons-codec.version>
-        <flyway.version>12.4.0</flyway.version>
+        <flyway.version>12.5.0</flyway.version>
         <hibernate.version>7.3.3.Final</hibernate.version>
         <jackson-2-bom.version>2.21.3</jackson-2-bom.version>
         <jackson-bom.version>3.1.3</jackson-bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ SPDX-License-Identifier: MIT
         <mockito.version>5.23.0</mockito.version>
         <mssql-jdbc.version>13.4.0.jre11</mssql-jdbc.version>
         <oracle-database.version>23.26.1.0.0</oracle-database.version>
-        <postgresql.version>42.7.10</postgresql.version>
+        <postgresql.version>42.7.11</postgresql.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>


### PR DESCRIPTION
- Bump `jackson-2-bom.version` from 2.21.2 to 2.21.3
- Bump `jackson-bom.version` from 3.1.2 to 3.1.3
- Bump `commons-codec.version` from 1.21.0 to 1.22.0
- Bump `flyway.version` from 12.4.0 to 12.5.0
- Bump `postgresql.version` from 42.7.10 to 42.7.11