### PR TITLE
HTM-2052: Use upsert for new session attributes to avoid conflicts with concurrent session updates

### DIFF
--- a/src/main/java/org/tailormap/api/configuration/JdbcSessionConfiguration.java
+++ b/src/main/java/org/tailormap/api/configuration/JdbcSessionConfiguration.java
@@ -35,6 +35,8 @@ public class JdbcSessionConfiguration implements BeanClassLoaderAware {
   private static final String CREATE_SESSION_ATTRIBUTE_QUERY = """
 INSERT INTO %TABLE_NAME%_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
 VALUES (?, ?, convert_from(?, 'UTF8')::jsonb)
+ON CONFLICT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME)
+DO UPDATE SET ATTRIBUTE_BYTES = EXCLUDED.ATTRIBUTE_BYTES
 """;
 
   private static final String UPDATE_SESSION_ATTRIBUTE_QUERY = """


### PR DESCRIPTION
[![HTM-2052](https://badgen.net/badge/JIRA/HTM-2052/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2052) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

 

[HTM-2052]: https://b3partners.atlassian.net/browse/HTM-2052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Avoids exception seen (possibly with concurrent session updates) on some authentication failures such as:

```
2026-05-21T12:46:14.526Z ERROR 1 --- [-8080-exec-2411] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception
org.springframework.dao.DuplicateKeyException: PreparedStatementCallback; SQL [INSERT INTO SPRING_SESSION_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
VALUES (?, ?, convert_from(?, 'UTF8')::jsonb)
]; ERROR: duplicate key value violates unique constraint "spring_session_attributes_pk"
  Detail: Key (session_primary_id, attribute_name)=(83517286-1ed5-46d3-86c8-7afcd4beaa6c, SPRING_SECURITY_LAST_EXCEPTION) already exists.
        at org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator.doTranslate(SQLErrorCodeSQLExceptionTranslator.java:252) ~[spring-jdbc-7.0.7.jar:7.0.7]
        at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:102) ~[spring-jdbc-7.0.7.jar:7.0.7]
        at org.springframework.jdbc.core.JdbcTemplate.translateException(JdbcTemplate.java:1549) ~[spring-jdbc-7.0.7.jar:7.0.7]
        at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:689) ~[spring-jdbc-7.0.7.jar:7.0.7]
        at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:966) ~[spring-jdbc-7.0.7.jar:7.0.7]
        at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:1010) ~[spring-jdbc-7.0.7.jar:7.0.7]
        at org.springframework.session.jdbc.JdbcIndexedSessionRepository.insertSessionAttributes(JdbcIndexedSessionRepository.java:565) ~[spring-session-jdbc-4.0.3.jar:4.0.3]
        at org.springframework.session.jdbc.JdbcIndexedSessionRepository$JdbcSession.lambda$save$10(JdbcIndexedSessionRepository.java:933) ~[spring-session-jdbc-4.0.3.jar:4.0.3]
        at org.springframework.session.jdbc.JdbcIndexedSessionRepository$JdbcSession.lambda$save$15(JdbcIndexedSessionRepository.java:957) ~[spring-session-jdbc-4.0.3.jar:4.0.3]
        at org.springframework.transaction.support.TransactionOperations.lambda$executeWithoutResult$0(TransactionOperations.java:68) ~[spring-tx-7.0.7.jar:7.0.7]
        at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:137) ~[spring-tx-7.0.7.jar:7.0.7]
        at org.springframework.transaction.support.TransactionOperations.executeWithoutResult(TransactionOperations.java:67) ~[spring-tx-7.0.7.jar:7.0.7]
        at org.springframework.session.jdbc.JdbcIndexedSessionRepository$JdbcSession.save(JdbcIndexedSessionRepository.java:955) ~[spring-session-jdbc-4.0.3.jar:4.0.3]
        at org.springframework.session.jdbc.JdbcIndexedSessionRepository.save(JdbcIndexedSessionRepository.java:477) ~[spring-session-jdbc-4.0.3.jar:4.0.3]
        at org.springframework.session.jdbc.JdbcIndexedSessionRepository.save(JdbcIndexedSessionRepository.java:141) ~[spring-session-jdbc-4.0.3.jar:4.0.3]
        at org.springframework.session.web.http.SessionRepositoryFilter$SessionRepositoryRequestWrapper.commitSession(SessionRepositoryFilter.java:229) ~[spring-session-core-4.0.3.jar:4.0.3]
        at org.springframework.session.web.http.SessionRepositoryFilter.doFilterInternal(SessionRepositoryFilter.java:145) ~[spring-session-core-4.0.3.jar:4.0.3]
        at org.springframework.session.web.http.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:82) ~[spring-session-core-4.0.3.jar:4.0.3]
```