### PR TITLE
HTM-2053: Ignore ProviderNotFoundException for OAuth2 authentication failures

### DIFF
--- a/src/main/java/org/tailormap/api/security/AuthenticationEventsLogger.java
+++ b/src/main/java/org/tailormap/api/security/AuthenticationEventsLogger.java
@@ -14,6 +14,7 @@ import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
 import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
@@ -98,6 +99,15 @@ public class AuthenticationEventsLogger {
   public void onFailure(AbstractAuthenticationFailureEvent failure) {
     Throwable exception = failure.getException();
     Throwable rootCause = getRootCause(exception);
+
+    if (exception instanceof ProviderNotFoundException
+        && failure.getAuthentication() instanceof OAuth2LoginAuthenticationToken) {
+      // Ignore, because after this generic exception another event will come with details about the actual OIDC
+      // authentication failure
+      // Prevents logging and incrementing the Micrometer counter for the authentication failure twice
+      logger.trace("Ignoring ProviderNotFoundException for OAuth2LoginAuthenticationToken", exception);
+      return;
+    }
 
     String oauth2Message = "";
     if (exception instanceof OAuth2AuthenticationException oauth2Ex && oauth2Ex.getError() != null) {


### PR DESCRIPTION
[![HTM-2053](https://badgen.net/badge/JIRA/HTM-2053/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2053) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

To prevent logging and counting OAuth2 authentication failure twice. 

[HTM-2053]: https://b3partners.atlassian.net/browse/HTM-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ