### PR TITLE
HTM-2054: Add system group refresh-capabilities

### DIFF
--- a/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
@@ -63,7 +63,9 @@ import org.tailormap.api.persistence.TMFeatureSource;
 import org.tailormap.api.persistence.TMFeatureType;
 import org.tailormap.api.persistence.Upload;
 import org.tailormap.api.persistence.User;
+import org.tailormap.api.persistence.helper.AdminAdditionalPropertyHelper;
 import org.tailormap.api.persistence.helper.GeoServiceHelper;
+import org.tailormap.api.persistence.json.AdminAdditionalProperty;
 import org.tailormap.api.persistence.json.AppContent;
 import org.tailormap.api.persistence.json.AppLayerSettings;
 import org.tailormap.api.persistence.json.AppSettings;
@@ -281,9 +283,17 @@ public class PopulateTestData {
     Group groupBaz = new Group().setName("test-baz").setDescription("Used for integration tests.");
     groupRepository.save(groupBaz);
 
+    Group refreshCapabilities =
+        groupRepository.findById(Group.REFRESH_CAPABILITIES).orElseThrow();
+    refreshCapabilities.setAdditionalProperties(List.of(new AdminAdditionalProperty()
+        .key(AdminAdditionalPropertyHelper.KEY_REFRESH_CAPABILITIES_SERVICES)
+        .isPublic(false)
+        .value(List.of("snapshot-geoserver", "does-not-exist"))));
+    groupRepository.flush();
+
     // Normal user
     User u = new User().setUsername("user").setPassword("{noop}user").setEmail("user@example.com");
-    u.getGroups().addAll(List.of(groupFoo, groupBar, groupBaz));
+    u.getGroups().addAll(List.of(groupFoo, groupBar, groupBaz, refreshCapabilities));
     userRepository.save(u);
 
     // Foo only user

--- a/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
+++ b/src/main/java/org/tailormap/api/configuration/dev/PopulateTestData.java
@@ -296,6 +296,10 @@ public class PopulateTestData {
     u.getGroups().addAll(List.of(groupFoo, groupBar, groupBaz, refreshCapabilities));
     userRepository.save(u);
 
+    u = new User().setUsername("refresher").setPassword("{noop}refresher").setName("Refresh geo services only");
+    u.getGroups().add(groupRepository.findById(Group.REFRESH_CAPABILITIES).orElseThrow());
+    userRepository.save(u);
+
     // Foo only user
     u = new User()
         .setUsername("foo")

--- a/src/main/java/org/tailormap/api/controller/admin/GeoServiceAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/GeoServiceAdminController.java
@@ -63,13 +63,13 @@ public class GeoServiceAdminController {
     // service ID in their additional properties
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-    boolean isAdmin = false;
+    assert authentication != null;
+    boolean isAdmin =
+        authentication.getAuthorities().stream().anyMatch(a -> Objects.equals(a.getAuthority(), Group.ADMIN));
+    boolean hasRefreshCapabilities = authentication.getAuthorities().stream()
+        .anyMatch(a -> Objects.equals(a.getAuthority(), Group.REFRESH_CAPABILITIES));
 
-    if (authentication != null && authentication.getPrincipal() instanceof TailormapUserDetails userDetails) {
-      isAdmin =
-          userDetails.getAuthorities().stream().anyMatch(a -> Objects.equals(a.getAuthority(), Group.ADMIN));
-      boolean hasRefreshCapabilities = userDetails.getAuthorities().stream()
-          .anyMatch(a -> Objects.equals(a.getAuthority(), Group.REFRESH_CAPABILITIES));
+    if (authentication.getPrincipal() instanceof TailormapUserDetails userDetails) {
       if (!isAdmin) {
         if (!hasRefreshCapabilities) {
           // Should not be allowed by securityMatchers in ApiSecurityConfiguration

--- a/src/main/java/org/tailormap/api/controller/admin/GeoServiceAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/GeoServiceAdminController.java
@@ -7,20 +7,38 @@
 package org.tailormap.api.controller.admin;
 
 import jakarta.servlet.http.HttpServletResponse;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.rest.core.event.BeforeSaveEvent;
 import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import org.tailormap.api.persistence.GeoService;
+import org.tailormap.api.persistence.Group;
+import org.tailormap.api.persistence.helper.AdminAdditionalPropertyHelper;
+import org.tailormap.api.persistence.json.GeoServiceLayer;
 import org.tailormap.api.repository.GeoServiceRepository;
+import org.tailormap.api.security.TailormapUserDetails;
 
 @RestController
 public class GeoServiceAdminController {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   private final GeoServiceRepository geoServiceRepository;
   private final ApplicationContext applicationContext;
   private final RepositoryEntityLinks repositoryEntityLinks;
@@ -35,22 +53,78 @@ public class GeoServiceAdminController {
   }
 
   @PostMapping(path = "${tailormap-api.admin.base-path}/geo-services/{id}/refresh-capabilities")
-  public ResponseEntity<GeoService> refreshCapabilities(
+  public ResponseEntity<List<GeoServiceLayer>> refreshCapabilities(
       @PathVariable String id, HttpServletResponse httpServletResponse) throws Exception {
 
     GeoService geoService =
         geoServiceRepository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
-    // Authorization check not needed: only admins are allowed on the admin base path, and admins
-    // have all access
+    // Check authorization: admins have full access, users with REFRESH_CAPABILITIES role need
+    // service ID in their additional properties
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    boolean isAdmin = false;
+
+    if (authentication != null && authentication.getPrincipal() instanceof TailormapUserDetails userDetails) {
+      isAdmin =
+          userDetails.getAuthorities().stream().anyMatch(a -> Objects.equals(a.getAuthority(), Group.ADMIN));
+      boolean hasRefreshCapabilities = userDetails.getAuthorities().stream()
+          .anyMatch(a -> Objects.equals(a.getAuthority(), Group.REFRESH_CAPABILITIES));
+      if (!isAdmin) {
+        if (!hasRefreshCapabilities) {
+          // Should not be allowed by securityMatchers in ApiSecurityConfiguration
+          throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+        final Set<String> allowedGeoServiceIds = userDetails.getAdditionalGroupProperties().stream()
+            .filter(p -> Objects.equals(
+                p.key(), AdminAdditionalPropertyHelper.KEY_REFRESH_CAPABILITIES_SERVICES))
+            .findFirst()
+            .map(p -> {
+              Set<String> allowedIds = new HashSet<>();
+              switch (p.value()) {
+                case null -> {
+                  return allowedIds;
+                }
+                case String stringValue ->
+                  allowedIds.addAll(Arrays.stream(stringValue.split(","))
+                      .map(String::trim)
+                      .toList());
+                case ArrayList<?> list ->
+                  list.stream()
+                      .filter(item -> item instanceof String)
+                      .map(item -> (String) item)
+                      .forEach(allowedIds::add);
+                default -> {}
+              }
+              return allowedIds;
+            })
+            .orElse(new HashSet<>());
+
+        if (!allowedGeoServiceIds.contains(geoService.getId())) {
+          throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+        logger.debug(
+            "User {} is authorized to refresh capabilities for GeoService {} (id: {})",
+            userDetails.getUsername(),
+            geoService.getTitle(),
+            geoService.getId());
+      }
+    }
 
     geoService.setRefreshCapabilities(true);
     applicationContext.publishEvent(new BeforeSaveEvent(geoService));
 
     geoServiceRepository.saveAndFlush(geoService);
 
-    httpServletResponse.sendRedirect(String.valueOf(
-        repositoryEntityLinks.linkToItemResource(GeoService.class, id).toUri()));
-    return null;
+    if (isAdmin) {
+      httpServletResponse.sendRedirect(String.valueOf(repositoryEntityLinks
+          .linkToItemResource(GeoService.class, id)
+          .toUri()));
+      return null;
+    } else {
+      // Do not redirect to the GeoService resource (which they don't have access to), but return the refreshed
+      // layers directly (which do not contain sensitive information such as authentication credentials)
+      return ResponseEntity.ok(geoService.getLayers());
+    }
   }
 }

--- a/src/main/java/org/tailormap/api/persistence/Group.java
+++ b/src/main/java/org/tailormap/api/persistence/Group.java
@@ -42,6 +42,7 @@ public class Group extends AuditMetadata {
   // Group to make authorization rules for authenticated users
   public static final String AUTHENTICATED = "authenticated";
   public static final String ADMIN = "admin";
+  public static final String REFRESH_CAPABILITIES = "refresh-capabilities";
   public static final String ACTUATOR = "actuator";
 
   @Id

--- a/src/main/java/org/tailormap/api/persistence/helper/AdminAdditionalPropertyHelper.java
+++ b/src/main/java/org/tailormap/api/persistence/helper/AdminAdditionalPropertyHelper.java
@@ -11,6 +11,8 @@ import java.util.function.Function;
 import org.tailormap.api.persistence.json.AdminAdditionalProperty;
 
 public class AdminAdditionalPropertyHelper {
+  public static final String KEY_REFRESH_CAPABILITIES_SERVICES = "refresh-capabilities-services";
+
   // these are known keys used in this API and other projects, do not reuse them for other purposes:
   //      used in Drawing
   public static final String KEY_DRAWINGS_ADMIN = "drawings-admin";

--- a/src/main/java/org/tailormap/api/repository/GeoServiceRepository.java
+++ b/src/main/java/org/tailormap/api/repository/GeoServiceRepository.java
@@ -15,9 +15,9 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.tailormap.api.persistence.GeoService;
-import org.tailormap.api.security.annotation.PreAuthorizeAdmin;
+import org.tailormap.api.persistence.Group;
 
-@PreAuthorizeAdmin
+@PreAuthorize("hasAnyAuthority('" + Group.ADMIN + "', '" + Group.REFRESH_CAPABILITIES + "')")
 @RepositoryRestResource(path = "geo-services", collectionResourceRel = "geo-services", itemResourceRel = "geo-service")
 public interface GeoServiceRepository
     extends JpaRepository<GeoService, String>, RevisionRepository<GeoService, String, Long> {

--- a/src/main/java/org/tailormap/api/security/ApiSecurityConfiguration.java
+++ b/src/main/java/org/tailormap/api/security/ApiSecurityConfiguration.java
@@ -139,6 +139,9 @@ public class ApiSecurityConfiguration {
             /* (debug) log user making the request */ new AuditInterceptor(),
             AnonymousAuthenticationFilter.class)
         .authorizeHttpRequests(authorize -> {
+          authorize
+              .requestMatchers(adminApiBasePath + "/geo-services/*/refresh-capabilities")
+              .hasAnyAuthority(Group.ADMIN, Group.REFRESH_CAPABILITIES);
           authorize.requestMatchers(adminApiBasePath + "/**").hasAuthority(Group.ADMIN);
           authorize.requestMatchers(apiBasePath + "/**").permitAll();
         })

--- a/src/main/resources/db/migration/V31__group_admin_refresh_capabilities.sql
+++ b/src/main/resources/db/migration/V31__group_admin_refresh_capabilities.sql
@@ -1,1 +1,1 @@
-insert into groups(name, system_group, description) values ('refresh-capabilities', true, 'Allows refreshing geo service capabilities for selected services only');
+insert into groups(name, version, system_group, description) values ('refresh-capabilities', 0,true, 'Allows refreshing geo service capabilities for selected services only');

--- a/src/main/resources/db/migration/V31__group_admin_refresh_capabilities.sql
+++ b/src/main/resources/db/migration/V31__group_admin_refresh_capabilities.sql
@@ -1,0 +1,1 @@
+insert into groups(name, system_group, description) values ('refresh-capabilities', true, 'Allows refreshing geo service capabilities for selected services only');

--- a/src/test/java/org/tailormap/api/controller/admin/GeoServiceAdminControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/admin/GeoServiceAdminControllerIntegrationTest.java
@@ -23,6 +23,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -137,6 +138,43 @@ class GeoServiceAdminControllerIntegrationTest {
           .andExpect(jsonPath("$.layers[2].crs.length()").value(1))
           .andExpect(jsonPath("$.layers[2].crs[0]").value("EPSG:4326"));
     }
+  }
+
+  @Test
+  @WithUserDetails("foo")
+  // No authorities: should not be able to refresh capabilities
+  void refresh_capabilities_user_not_allowed() throws Exception {
+    MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build(); // Required for Spring Data Rest APIs
+
+    mockMvc.perform(post(adminBasePath + "/geo-services/snapshot-geoserver/refresh-capabilities"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithUserDetails("user")
+  void refresh_capabilities_geo_service_not_found() throws Exception {
+    MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build(); // Required for Spring Data Rest APIs
+
+    mockMvc.perform(post(adminBasePath + "/geo-services/does-not-exist/refresh-capabilities"))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithUserDetails("user")
+  void refresh_capabilities_geo_service_not_configured_not_allowed() throws Exception {
+    MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build(); // Required for Spring Data Rest APIs
+
+    mockMvc.perform(post(adminBasePath + "/geo-services/pdok-kadaster-bestuurlijkegebieden/refresh-capabilities"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithUserDetails("user")
+  void refresh_capabilities_user_allowed() throws Exception {
+    MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build(); // Required for Spring Data Rest APIs
+
+    mockMvc.perform(post(adminBasePath + "/geo-services/snapshot-geoserver/refresh-capabilities"))
+        .andExpect(status().isOk());
   }
 
   /**

--- a/src/test/java/org/tailormap/api/controller/admin/GeoServiceAdminControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/admin/GeoServiceAdminControllerIntegrationTest.java
@@ -160,7 +160,10 @@ class GeoServiceAdminControllerIntegrationTest {
   }
 
   @Test
-  @WithUserDetails("user")
+  // TODO use custom UserDetailsService for test that either returns Group without the KEY_REFRESH_CAPABILITIES_SERVICES
+  // property (or which doesn't contain the service to refresh) and that does, to test this and next use cases
+  @WithUserDetails("refresher")
+
   void refresh_capabilities_geo_service_not_configured_not_allowed() throws Exception {
     MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build(); // Required for Spring Data Rest APIs
 
@@ -169,7 +172,7 @@ class GeoServiceAdminControllerIntegrationTest {
   }
 
   @Test
-  @WithUserDetails("user")
+  @WithUserDetails("refresher")
   void refresh_capabilities_user_allowed() throws Exception {
     MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build(); // Required for Spring Data Rest APIs
 


### PR DESCRIPTION
[![HTM-2054](https://badgen.net/badge/JIRA/HTM-2054/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2054) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This group is authorized to refresh only selected geo services. Usecase is a Tailormap application with frontend extension that dynamically adds a new layer with a filter to a geoservice that should be shareable/reusable in other Tailormap viewers. This requires the possibility to refresh the service capabilities by an end user. With only this extra group (and configuration to be able to refresh only geoservices configured in additional property in the group), the minimal amount of extra rights are granted.

Test using a non-admin user account with refresh-capabilities group membership, with refresh-capabilities Groups.additionalProperties set to:

```
[
  {
    "key": "refresh-capabilities-services",
    "value": ["snapshot-geoserver","pietje"],
    "isPublic": false
  }
]
```
or
```
[
  {
    "key": "refresh-capabilities-services",
    "value": "snapshot-geoserver,pietje",
    "isPublic": false
  }
]
```

Fetch test:
```javascript
fetch("http://localhost:4200/api/admin/geo-services/snapshot-geoserver/refresh-capabilities", {
  "headers": {
    "accept": "application/json, text/plain, */*",
    "accept-language": "nl,en-US;q=0.9,en;q=0.8",
    "content-type": "application/json",
  },
  "referrer": "http://localhost:4200/app/default",
  "body": "{}",
  "method": "POST",
  "mode": "cors",
  "credentials": "include"
}).then(r => r.json().then(console.log));
```

Note: when admin, this API redirects to `/api/admin/geo-services/snapshot-geoserver` which requires admin rights (because this may include auth credentials, settings, etc). So when only authorized for refresh-capabilities, this API now just returns the non-sensitive list of layers.

[HTM-2051]: https://b3partners.atlassian.net/browse/HTM-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 

[HTM-2054]: https://b3partners.atlassian.net/browse/HTM-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ