### PR TITLE
HTM-2057: Add sqlite-jdbc version override 3.53.1.0 to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@ SPDX-License-Identifier: MIT
         <mssql-jdbc.version>13.4.0.jre11</mssql-jdbc.version>
         <oracle-database.version>23.26.1.0.0</oracle-database.version>
         <postgresql.version>42.7.11</postgresql.version>
+        <sqlite-jdbc.version>3.53.1.0</sqlite-jdbc.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>


### PR DESCRIPTION
[![HTM-2057](https://badgen.net/badge/JIRA/HTM-2057/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2057) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Spring Boot is shipping with an outdated version that also downgrades the version used for GeoTools / Geopackage functionality.

The version used is flagged with CVE-2025-70873, resolves https://github.com/Tailormap/tailormap-api/security/code-scanning/499 

[HTM-2057]: https://b3partners.atlassian.net/browse/HTM-2057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ