### PR TITLE
HTM-2058: Update Hibernate version to 7.4.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,8 @@ SPDX-License-Identifier: MIT
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-codec.version>1.22.0</commons-codec.version>
         <flyway.version>12.8.0</flyway.version>
+        <!--  TODO: when updating hibernate to 7.4.1.Final or later, remove
+                    the workaround for HHH-20518, see HTM-2068 -->
         <hibernate.version>7.4.0.Final</hibernate.version>
         <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
         <jackson-bom.version>3.1.4</jackson-bom.version>
@@ -758,6 +760,19 @@ SPDX-License-Identifier: MIT
                     <groupId>org.hibernate.orm</groupId>
                     <artifactId>hibernate-maven-plugin</artifactId>
                     <version>${hibernate.version}</version>
+                    <dependencies>
+                        <!--
+                        TODO: remove after upgrading hibernate-maven-plugin to a version that has a fix
+                               for https://hibernate.atlassian.net/browse/HHH-20518
+                               presumably in hibernate-maven-plugin 7.4.1.Final or later
+                               see https://b3partners.atlassian.net/browse/HTM-2068 for details
+                        -->
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-utils</artifactId>
+                            <version>4.0.3</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-pmd-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ SPDX-License-Identifier: MIT
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-codec.version>1.22.0</commons-codec.version>
         <flyway.version>12.8.0</flyway.version>
-        <hibernate.version>7.3.7.Final</hibernate.version>
+        <hibernate.version>7.4.0.Final</hibernate.version>
         <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
         <jackson-bom.version>3.1.4</jackson-bom.version>
         <json-path.version>3.0.0</json-path.version>


### PR DESCRIPTION
[![HTM-2058](https://badgen.net/badge/JIRA/HTM-2058/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2058) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

see https://hibernate.org/orm/releases/7.4/ 

**Note**: this does not provide the [optional refactoring/migration from Hibernate Envers to core `@Audited`](https://docs.hibernate.org/orm/7.4/migration-guide/#envers-migration) as we are using the Spring Boot Envers module, which may or may not catch up in a new (major) Spring Boot version.

Build failures/bug reported in [HHH-20518](https://hibernate.atlassian.net/browse/HHH-20518), a workaround for this [bug](https://hibernate.atlassian.net/browse/HHH-20518) was added in 0edc7f10ee0b59e4b77d5dcedbd9266c42dda47b

[HTM-2058]: https://b3partners.atlassian.net/browse/HTM-2058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ