### PR TITLE
Update PMD ruleset to use JUnit Jupiter naming

### DIFF
--- a/build/qa/PMD-ruleset_for_TM.xml
+++ b/build/qa/PMD-ruleset_for_TM.xml
@@ -117,7 +117,7 @@ SPDX-License-Identifier: MIT
         </properties>
     </rule>
     <rule ref="category/java/bestpractices.xml/SimplifiableTestAssertion"/>
-    <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate"/>
+    <rule ref="category/java/bestpractices.xml/JUnitJupiterTestShouldBePackagePrivate"/>
     <rule ref="category/java/errorprone.xml/UnnecessaryBooleanAssertion"/>
     <rule name="DisallowJunit3" language="java" message="Using JUnit3 is not allowed"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">


### PR DESCRIPTION
Use Rule name category/java/bestpractices.xml/JUnitJupiterTestShouldBePackagePrivate instead of the deprecated Rule name category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate. PMD 8.0.0 will remove support for this deprecated Rule name usage.