### PR TITLE
HTM-2059: Use 35-RC version for excel datastore and remove the autosizing option

### DIFF
--- a/src/main/java/org/tailormap/api/service/CreateLayerExtractService.java
+++ b/src/main/java/org/tailormap/api/service/CreateLayerExtractService.java
@@ -381,10 +381,6 @@ public class CreateLayerExtractService {
           DataUtilities.createSubType(inputFeatureSource.getSchema(), attributes.toArray(new String[0]));
       outputDataStore.createSchema(fType);
 
-      if (outputDataStore instanceof ExcelDataStore excelDataStore) {
-        excelDataStore.setEnableCellAutoSizing(featCount >= 0 && featCount < 1000);
-      }
-
       final AtomicInteger featsAdded = new AtomicInteger();
       if (outputDataStore.getFeatureSource() instanceof SimpleFeatureStore featureStore) {
         featureStore.setTransaction(outputTransaction);


### PR DESCRIPTION
[![HTM-2059](https://badgen.net/badge/JIRA/HTM-2059/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2059) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

requires https://github.com/Tailormap/gt-excel-writer/pull/8

Note thet the excel module was re-published as 35-RC with a bugfix for HTM-2059

[HTM-2059]: https://b3partners.atlassian.net/browse/HTM-2059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ