### PR TITLE
HTM-1727: set the `server.shutdown` option to `immediate`

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -3,8 +3,9 @@
 # Disable CSRF protection for modifying HTTP requests using HAL explorer, issue DATAREST-980
 tailormap-api.security.disable-csrf=true
 
-server.error.include-stacktrace=always
-server.error.include-message=always
+spring.web.error.include-stacktrace=always
+spring.web.error.include-message=always
+server.shutdown=immediate
 
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=false


### PR DESCRIPTION
[![HTM-1727](https://badgen.net/badge/JIRA/HTM-1727/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1727) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Disable graceful server shutdown for development profile. This will prevent waiting until timeout, because there can be open (SSE) connections.

See https://docs.spring.io/spring-boot/reference/web/graceful-shutdown.html

Alternatively you could configure the `spring.lifecycle.timeout-per-shutdown-phase` to be much less that the default 30s

Also update deprecated error option keys. 

[HTM-1727]: https://b3partners.atlassian.net/browse/HTM-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ