### PR TITLE
 Jackson 2 and 3 dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <commons-codec.version>1.22.0</commons-codec.version>
         <flyway.version>12.6.1</flyway.version>
         <hibernate.version>7.3.7.Final</hibernate.version>
-        <jackson-2-bom.version>2.21.3</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
         <jackson-bom.version>3.1.4</jackson-bom.version>
         <json-path.version>3.0.0</json-path.version>
         <junit-jupiter.version>6.1.0</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ SPDX-License-Identifier: MIT
         <flyway.version>12.6.1</flyway.version>
         <hibernate.version>7.3.7.Final</hibernate.version>
         <jackson-2-bom.version>2.21.3</jackson-2-bom.version>
-        <jackson-bom.version>3.1.3</jackson-bom.version>
+        <jackson-bom.version>3.1.4</jackson-bom.version>
         <json-path.version>3.0.0</json-path.version>
         <junit-jupiter.version>6.1.0</junit-jupiter.version>
         <micrometer.version>1.16.5</micrometer.version>


### PR DESCRIPTION
- Bump jackson-bom.version from 3.1.3 to 3.1.4
- Bump jackson2-bom.version from 2.21.3 to 2.22.0