### PR TITLE
Upgrade Flyway version from 12.6.1 to 12.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@ SPDX-License-Identifier: MIT
         <awaitility.version>4.3.0</awaitility.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-codec.version>1.22.0</commons-codec.version>
-        <flyway.version>12.6.1</flyway.version>
+        <flyway.version>12.8.0</flyway.version>
         <hibernate.version>7.3.7.Final</hibernate.version>
         <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
         <jackson-bom.version>3.1.4</jackson-bom.version>


### PR DESCRIPTION
see https://documentation.red-gate.com/flyway/release-notes-and-older-versions/release-notes-for-flyway-engine