### PR TITLE
HTM-2097: Increase Hikari connection pool max size from default 10 to 30

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -129,7 +129,7 @@ spring.datasource.url=jdbc:postgresql:tailormap
 spring.datasource.username=tailormap
 spring.datasource.password=tailormap
 #spring.datasource.driver-class-name=com.p6spy.engine.spy.P6SpyDriver
-spring.datasource.pool-size=30
+spring.datasource.hikari.maximum-pool-size=30
 
 spring.session.jdbc.initialize-schema=always
 spring.session.jdbc.schema=classpath:db/sessionschema.sql


### PR DESCRIPTION
[![HTM-2097](https://badgen.net/badge/JIRA/HTM-2097/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2097) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

 

[HTM-2097]: https://b3partners.atlassian.net/browse/HTM-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ