### PR TITLE
HTM-1852 | HTM-1964: Upgrade to GeoTools 35.0 and re-instate GeoJSON extract

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ SPDX-License-Identifier: MIT
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <project.build.outputTimestamp>2026-07-01T09:25:23Z</project.build.outputTimestamp>
-        <geotools.version>35-RC</geotools.version>
+        <geotools.version>35.0</geotools.version>
         <jts.version>1.20.0</jts.version>
         <okhttp.version>5.4.0</okhttp.version>
         <greenmail.version>2.1.9</greenmail.version>

--- a/src/main/java/org/tailormap/api/configuration/GeoToolsConfiguration.java
+++ b/src/main/java/org/tailormap/api/configuration/GeoToolsConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.configuration;
+
+import jakarta.annotation.PostConstruct;
+import java.lang.invoke.MethodHandles;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Configuration;
+import org.tailormap.api.geotools.TMPreventLocalEntityResolver;
+
+@Configuration
+public class GeoToolsConfiguration {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @PostConstruct
+  public void init() {
+    GeoTools.init(new Hints(Hints.ENTITY_RESOLVER, TMPreventLocalEntityResolver.INSTANCE));
+    if (logger.isTraceEnabled()) {
+      logger.trace("GeoTools initialised: {}", GeoTools.getAboutInfo());
+      logger.trace("GeoTools default hints: {}", GeoTools.getDefaultHints());
+    }
+  }
+}

--- a/src/main/java/org/tailormap/api/geotools/TMPreventLocalEntityResolver.java
+++ b/src/main/java/org/tailormap/api/geotools/TMPreventLocalEntityResolver.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.geotools;
+
+import java.io.IOException;
+import org.geotools.util.PreventLocalEntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * An entity resolver that extends the {@link PreventLocalEntityResolver} to allow certain DescribeFeatureType requests
+ * commonly produced by GeoServer.
+ *
+ * @see <a href="https://osgeo-org.atlassian.net/browse/GEOT-7916">GEOT-7916</a>
+ */
+public class TMPreventLocalEntityResolver extends PreventLocalEntityResolver {
+  public static final TMPreventLocalEntityResolver INSTANCE = new TMPreventLocalEntityResolver();
+
+  private static final java.util.regex.Pattern DESCRIBE_FEATURE_TYPE_URL = java.util.regex.Pattern.compile(
+      "^https?://[^?#;]*\\?(?:[^#;]*[&;])?request=DescribeFeatureType(?:[&;]|$).*",
+      java.util.regex.Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Next to what the base class allows, explicitly allow (dynamic) {@code DescribeFeatureType} requests such as
+   * {@code https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/wfs/v1_0?SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=bestuurlijkegebieden:Provinciegebied&OUTPUTFORMAT=application%2Fgml%2Bxml%3B%20version%3D3.2}
+   * commonly produced by GeoServer.
+   */
+  @Override
+  public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId)
+      throws SAXException, IOException {
+
+    if (systemId != null && DESCRIBE_FEATURE_TYPE_URL.matcher(systemId).matches()) {
+      return null;
+    }
+    return super.resolveEntity(name, publicId, baseURI, systemId);
+  }
+}

--- a/src/main/java/org/tailormap/api/geotools/featuresources/WFSFeatureSourceHelper.java
+++ b/src/main/java/org/tailormap/api/geotools/featuresources/WFSFeatureSourceHelper.java
@@ -14,9 +14,9 @@ import org.geotools.api.data.ResourceInfo;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.internal.FeatureTypeInfo;
-import org.geotools.util.PreventLocalEntityResolver;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.tailormap.api.geotools.TMPreventLocalEntityResolver;
 import org.tailormap.api.geotools.wfs.SimpleWFSHelper;
 import org.tailormap.api.persistence.TMFeatureSource;
 import org.tailormap.api.persistence.TMFeatureType;
@@ -28,7 +28,7 @@ public class WFSFeatureSourceHelper extends FeatureSourceHelper {
   @Override
   public DataStore createDataStore(TMFeatureSource tmfs, Integer timeout) throws IOException {
     Map<String, Object> params = new HashMap<>();
-    params.put(WFSDataStoreFactory.ENTITY_RESOLVER.key, PreventLocalEntityResolver.INSTANCE);
+    params.put(WFSDataStoreFactory.ENTITY_RESOLVER.key, TMPreventLocalEntityResolver.INSTANCE);
 
     if (timeout != null) {
       params.put(WFSDataStoreFactory.TIMEOUT.key, timeout);

--- a/src/main/java/org/tailormap/api/persistence/helper/GeoServiceHelper.java
+++ b/src/main/java/org/tailormap/api/persistence/helper/GeoServiceHelper.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -33,6 +34,7 @@ import org.geotools.ows.wms.WMSCapabilities;
 import org.geotools.ows.wms.WebMapServer;
 import org.geotools.ows.wmts.WebMapTileServer;
 import org.geotools.ows.wmts.model.WMTSLayer;
+import org.geotools.xml.DocumentFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -293,10 +295,15 @@ public class GeoServiceHelper {
     }
   }
 
-  void loadWMSCapabilities(GeoService geoService, ResponseTeeingHTTPClient client) throws Exception {
+  private void loadWMSCapabilities(GeoService geoService, ResponseTeeingHTTPClient client) throws Exception {
     WebMapServer wms;
     try {
-      wms = new WebMapServer(new URI(geoService.getUrl()).toURL(), client);
+      wms = new WebMapServer(
+          new URI(geoService.getUrl()).toURL(),
+          client,
+          Map.of(
+              // allow DTD for WMS 1.1.x
+              DocumentFactory.ENABLE_DTD, true));
     } catch (ClassCastException | IllegalStateException e) {
       // The gt-wms module tries to cast the XML unmarshalling result expecting capabilities, but a
       // WMS 1.0.0/1.1.0 ServiceException may have been unmarshalled which leads to a
@@ -380,7 +387,7 @@ public class GeoServiceHelper {
         Set.of());
   }
 
-  void loadWMTSCapabilities(GeoService geoService, ResponseTeeingHTTPClient client) throws Exception {
+  private void loadWMTSCapabilities(GeoService geoService, ResponseTeeingHTTPClient client) throws Exception {
     WebMapTileServer wmts = new WebMapTileServer(new URI(geoService.getUrl()).toURL(), client);
     setServiceInfo(geoService, client, wmts);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,7 +26,7 @@ tailormap-api.features.wfs_count_exact=false
 tailormap-api.feature.info.maxitems=30
 
 # see org.tailormap.api.controller.LayerExtractController.ExtractOutputFormat for valid values
-tailormap-api.extract.allowed-outputformats=csv,xlsx,shape,geopackage
+tailormap-api.extract.allowed-outputformats=csv,xlsx,shape,geopackage,geojson
 # any files older than this (in minutes) in the extract output directory will be deleted by a scheduled job, to prevent filling up the disk
 # tailormap-api.extract.cleanup-minutes=120
 # the (base) directory where the extract output files are stored, should be writable by the application

--- a/src/test/java/org/tailormap/api/controller/LayerExtractControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExtractControllerIntegrationTest.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junitpioneer.jupiter.DisabledUntil;
 import org.junitpioneer.jupiter.Stopwatch;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -407,10 +406,6 @@ class LayerExtractControllerIntegrationTest extends SseParsingUtils {
     }
   }
 
-  @DisabledUntil(
-      date = "2026-09-01",
-      reason =
-          "This test relies on GeoTools 35.0 (or 34.4), see https://osgeo-org.atlassian.net/browse/GEOT-7894")
   @Test
   void should_export_large_filter_to_geojson() throws Exception {
     final String extractUrl = apiBasePath + layerBegroeidTerreindeelPostgis + extractPath + sseClientId;

--- a/src/test/java/org/tailormap/api/controller/admin/GeoServiceAdminControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/admin/GeoServiceAdminControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.tailormap.api.StaticTestData.getResourceString;
 
 import com.jayway.jsonpath.JsonPath;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import okhttp3.Headers;
@@ -105,7 +106,9 @@ class GeoServiceAdminControllerIntegrationTest {
 
       assertEquals(
           "GetCapabilities",
-          Objects.requireNonNull(server.takeRequest().getUrl()).queryParameter("REQUEST"));
+          Objects.requireNonNull(Objects.requireNonNull(server.takeRequest(10, TimeUnit.SECONDS))
+                  .getUrl())
+              .queryParameter("REQUEST"));
 
       // This capabilities document has an extra layer
       body = getResourceString(wmsTestCapabilitiesUpdated);
@@ -118,7 +121,9 @@ class GeoServiceAdminControllerIntegrationTest {
 
       assertEquals(
           "GetCapabilities",
-          Objects.requireNonNull(server.takeRequest().getUrl()).queryParameter("REQUEST"));
+          Objects.requireNonNull(Objects.requireNonNull(server.takeRequest(10, TimeUnit.SECONDS))
+                  .getUrl())
+              .queryParameter("REQUEST"));
 
       mockMvc.perform(get(selfLink).accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isOk())

--- a/src/test/java/org/tailormap/api/geotools/TMPreventLocalEntityResolverTest.java
+++ b/src/test/java/org/tailormap/api/geotools/TMPreventLocalEntityResolverTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.geotools;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+class TMPreventLocalEntityResolverTest {
+  @Test
+  void should_allow_http_describeFeatureType_requests() throws Exception {
+    String systemId =
+        "https://service.example.org/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=ns:Type";
+    InputSource result = TMPreventLocalEntityResolver.INSTANCE.resolveEntity(
+        "name", "publicId", "https://service.example.org/wfs", systemId);
+    assertNull(result, "DescribeFeatureType HTTP requests should be allowed (resolver returns null)");
+  }
+
+  @Test
+  void should_allow_describeFeatureType_request_case_insensitive_and_with_other_query_params() throws Exception {
+    String systemId = "http://host/service?foo=bar&request=DescribeFeatureTYPE&other=1";
+    InputSource result =
+        TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, "http://host/service", systemId);
+    assertNull(result);
+  }
+
+  @Test
+  void should_allow_absolute_http_xsd_uris() throws Exception {
+    String systemId = "http://schemas.example.org/some/schema.xsd";
+    InputSource result = TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, systemId);
+    assertNull(result, "Absolute http(s) .xsd URIs must be allowed by the resolver");
+  }
+
+  @Test
+  void should_allow_relative_xsd_resolved_against_baseUri() throws Exception {
+    String baseURI = "http://schemas.example.org/path/";
+    String systemId = "schema.xsd";
+    InputSource result = TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, baseURI, systemId);
+    assertNull(result, "Relative .xsd should be resolved against baseURI and allowed");
+  }
+
+  @Test
+  void should_reject_file_scheme_systemId() {
+    String systemId = "file:///etc/passwd";
+    assertThrows(
+        SAXException.class,
+        () -> TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, systemId));
+  }
+
+  @Test
+  void should_allow_absolute_https_scheme_systemId() throws Exception {
+    String systemId = "https://example.org/schema.xsd";
+    InputSource result = TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, systemId);
+    assertNull(result, "Absolute https .xsd URIs must be allowed by the resolver");
+  }
+
+  @Test
+  void should_throw_when_systemId_is_null() {
+    assertThrows(
+        SAXException.class, () -> TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, null));
+  }
+
+  @Test
+  void should_throw_when_protocol_is_not_supported() {
+    String systemId =
+        "file://service.example.org/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=ns:Type";
+    assertThrows(
+        SAXException.class,
+        () -> TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, systemId));
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,7 +3,7 @@ tailormap-api.admin.base-path=/api/admin
 management.endpoints.web.base-path=/api/actuator
 tailormap-api.new-admin-username=tm-admin
 # see org.tailormap.api.controller.LayerExtractController.ExtractOutputFormat for valid values
-tailormap-api.extract.allowed-outputformats=csv,xlsx,shape,geopackage
+tailormap-api.extract.allowed-outputformats=csv,xlsx,shape,geopackage,geojson
 # the number of features after which a progress report is sent back to the viewer, to update the progress bar
 tailormap-api.extract.progress-report-interval=10
 # any files older than this (in minutes) in the extract output directory will be deleted by a scheduled job, to prevent filling up the disk


### PR DESCRIPTION
[![HTM-1852](https://badgen.net/badge/JIRA/HTM-1852/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1852) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

[![HTM-1964](https://badgen.net/badge/JIRA/HTM-1964/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-1964)

* Initialise GeoTools on application startup and set our preferred entity resolver
* Add an entity resolver that explicity allows DescribeFeatureType (dynamic schema) requests to work around https://osgeo-org.atlassian.net/browse/GEOT-7916
* Allow WMS capabilities loading to use DTD (required for 1.1.x)

[HTM-1852]: https://b3partners.atlassian.net/browse/HTM-1852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-1964]: https://b3partners.atlassian.net/browse/HTM-1964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ