### PR TITLE
Fix GeoTools blocking (WFS) DescribeFeatureType requests

### DIFF
--- a/src/main/java/org/tailormap/api/configuration/GeoToolsConfiguration.java
+++ b/src/main/java/org/tailormap/api/configuration/GeoToolsConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.configuration;
+
+import jakarta.annotation.PostConstruct;
+import java.lang.invoke.MethodHandles;
+import org.geotools.util.PreventLocalEntityResolver;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GeoToolsConfiguration {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @PostConstruct
+  public void init() {
+    logger.debug("Initialising GeoTools");
+    GeoTools.init(new Hints(Hints.ENTITY_RESOLVER, PreventLocalEntityResolver.INSTANCE));
+    logger.debug("GeoTools initialised: {}", GeoTools.getAboutInfo());
+    logger.debug("GeoTools default hints: {}", GeoTools.getDefaultHints());
+  }
+}

--- a/src/main/java/org/tailormap/api/configuration/GeoToolsConfiguration.java
+++ b/src/main/java/org/tailormap/api/configuration/GeoToolsConfiguration.java
@@ -7,12 +7,12 @@ package org.tailormap.api.configuration;
 
 import jakarta.annotation.PostConstruct;
 import java.lang.invoke.MethodHandles;
-import org.geotools.util.PreventLocalEntityResolver;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
+import org.tailormap.api.geotools.TMPreventLocalEntityResolver;
 
 @Configuration
 public class GeoToolsConfiguration {
@@ -22,8 +22,10 @@ public class GeoToolsConfiguration {
   @PostConstruct
   public void init() {
     logger.debug("Initialising GeoTools");
-    GeoTools.init(new Hints(Hints.ENTITY_RESOLVER, PreventLocalEntityResolver.INSTANCE));
-    logger.debug("GeoTools initialised: {}", GeoTools.getAboutInfo());
-    logger.debug("GeoTools default hints: {}", GeoTools.getDefaultHints());
+    GeoTools.init(new Hints(Hints.ENTITY_RESOLVER, TMPreventLocalEntityResolver.INSTANCE));
+    if (logger.isDebugEnabled()) {
+      logger.debug("GeoTools initialised: {}", GeoTools.getAboutInfo());
+      logger.debug("GeoTools default hints: {}", GeoTools.getDefaultHints());
+    }
   }
 }

--- a/src/main/java/org/tailormap/api/geotools/TMPreventLocalEntityResolver.java
+++ b/src/main/java/org/tailormap/api/geotools/TMPreventLocalEntityResolver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.geotools;
+
+import java.io.IOException;
+import org.geotools.util.PreventLocalEntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * An entity resolver that extends the {@link PreventLocalEntityResolver} to allow certain DescribeFeatureType requests
+ * commonly produced by GeoServer.
+ *
+ * @see <a href="https://osgeo-org.atlassian.net/browse/GEOT-7916">GEOT-7916</a>
+ */
+public class TMPreventLocalEntityResolver extends PreventLocalEntityResolver {
+  public static final TMPreventLocalEntityResolver INSTANCE = new TMPreventLocalEntityResolver();
+
+  /**
+   * Next to what the base class allows, explicitly allow (dynamic) {@code DescribeFeatureType} requests such as
+   * {@code https://service.pdok.nl/kadaster/brk-bestuurlijke-gebieden/wfs/v1_0?SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=bestuurlijkegebieden:Provinciegebied&OUTPUTFORMAT=application%2Fgml%2Bxml%3B%20version%3D3.2}
+   * commonly produced by GeoServer.
+   */
+  @Override
+  public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId)
+      throws SAXException, IOException {
+
+    if (systemId != null
+        && systemId.matches("(?i)^https?://[^?#;]*\\?(?:[^#;]*[&;])?request=DescribeFeatureType(?:[&;]|$).*")) {
+      return null;
+    }
+    return super.resolveEntity(name, publicId, baseURI, systemId);
+  }
+}

--- a/src/main/java/org/tailormap/api/geotools/featuresources/WFSFeatureSourceHelper.java
+++ b/src/main/java/org/tailormap/api/geotools/featuresources/WFSFeatureSourceHelper.java
@@ -14,9 +14,9 @@ import org.geotools.api.data.ResourceInfo;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.internal.FeatureTypeInfo;
-import org.geotools.util.PreventLocalEntityResolver;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.tailormap.api.geotools.TMPreventLocalEntityResolver;
 import org.tailormap.api.geotools.wfs.SimpleWFSHelper;
 import org.tailormap.api.persistence.TMFeatureSource;
 import org.tailormap.api.persistence.TMFeatureType;
@@ -28,7 +28,7 @@ public class WFSFeatureSourceHelper extends FeatureSourceHelper {
   @Override
   public DataStore createDataStore(TMFeatureSource tmfs, Integer timeout) throws IOException {
     Map<String, Object> params = new HashMap<>();
-    params.put(WFSDataStoreFactory.ENTITY_RESOLVER.key, PreventLocalEntityResolver.INSTANCE);
+    params.put(WFSDataStoreFactory.ENTITY_RESOLVER.key, TMPreventLocalEntityResolver.INSTANCE);
 
     if (timeout != null) {
       params.put(WFSDataStoreFactory.TIMEOUT.key, timeout);

--- a/src/test/java/org/tailormap/api/geotools/TMPreventLocalEntityResolverTest.java
+++ b/src/test/java/org/tailormap/api/geotools/TMPreventLocalEntityResolverTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.geotools;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+class TMPreventLocalEntityResolverTest {
+  @Test
+  void should_allow_http_describeFeatureType_requests() throws Exception {
+    String systemId =
+        "https://service.example.org/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=ns:Type";
+    InputSource result = TMPreventLocalEntityResolver.INSTANCE.resolveEntity(
+        "name", "publicId", "https://service.example.org/wfs", systemId);
+    assertNull(result, "DescribeFeatureType HTTP requests should be allowed (resolver returns null)");
+  }
+
+  @Test
+  void should_allow_describeFeatureType_request_case_insensitive_and_with_other_query_params() throws Exception {
+    String systemId = "http://host/service?foo=bar&request=DescribeFeatureTYPE&other=1";
+    InputSource result =
+        TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, "http://host/service", systemId);
+    assertNull(result);
+  }
+
+  @Test
+  void should_allow_absolute_http_xsd_uris() throws Exception {
+    String systemId = "http://schemas.example.org/some/schema.xsd";
+    InputSource result = TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, systemId);
+    assertNull(result, "Absolute http(s) .xsd URIs must be allowed by the resolver");
+  }
+
+  @Test
+  void should_allow_relative_xsd_resolved_against_baseUri() throws Exception {
+    String baseURI = "http://schemas.example.org/path/";
+    String systemId = "schema.xsd";
+    InputSource result = TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, baseURI, systemId);
+    assertNull(result, "Relative .xsd should be resolved against baseURI and allowed");
+  }
+
+  @Test
+  void should_reject_file_scheme_systemId() {
+    String systemId = "file:///etc/passwd";
+    assertThrows(
+        SAXException.class,
+        () -> TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, systemId));
+  }
+
+  @Test
+  void should_allow_absolute_https_scheme_systemId() throws Exception {
+    String systemId = "https://example.org/schema.xsd";
+    InputSource result = TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, systemId);
+    assertNull(result, "Absolute https .xsd URIs must be allowed by the resolver");
+  }
+
+  @Test
+  void should_throw_when_systemId_is_null() {
+    assertThrows(
+        SAXException.class, () -> TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, null));
+  }
+
+  @Test
+  void should_throw_when_protocol_is_not_supported() {
+    String systemId =
+        "file://service.example.org/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=ns:Type";
+    assertThrows(
+        SAXException.class,
+        () -> TMPreventLocalEntityResolver.INSTANCE.resolveEntity(null, null, null, systemId));
+  }
+}


### PR DESCRIPTION
- [x] Initialise GeoTools on application startup and set our preferred entity resolver
- [x] Add an entity resolver that explicity allows DescribeFeatureType (dynamic schema) requests to work around https://osgeo-org.atlassian.net/browse/GEOT-7916