### PR TITLE
HTM-2106: Use the layers abstractText when no description is provided

### DIFF
--- a/src/main/java/org/tailormap/api/persistence/helper/ApplicationHelper.java
+++ b/src/main/java/org/tailormap/api/persistence/helper/ApplicationHelper.java
@@ -389,7 +389,8 @@ public class ApplicationHelper {
       String description = ObjectUtils.firstNonNull(
           nullIfEmpty(appLayerSettings.getDescription()),
           nullIfEmpty(serviceLayerSettings.getDescription()),
-          nullIfEmpty(defaultLayerSettings.getDescription()));
+          nullIfEmpty(defaultLayerSettings.getDescription()),
+          nullIfEmpty(serviceLayer.getAbstractText()));
       @SuppressModernizer
       String attribution = ObjectUtils.firstNonNull(
           nullIfEmpty(appLayerSettings.getAttribution()),

--- a/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/ViewerControllerIntegrationTest.java
@@ -220,6 +220,13 @@ class ViewerControllerIntegrationTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(
+            // layer description from WMS layer abstract
+            jsonPath("$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:bak')].description")
+                .value(
+                    contains(
+                        startsWith(
+                            "Object met een permanent karakter dat dient om iets in te bergen of te verzamelen"))))
+        .andExpect(
             // Application layer description
             jsonPath(
                     "$.appLayers[?(@.id === 'lyr:snapshot-geoserver:postgis:begroeidterreindeel')].description")


### PR DESCRIPTION
[![HTM-2106](https://badgen.net/badge/JIRA/HTM-2106/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2106) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

After checking if none of the app-, service- or default-layersettings provide a description using the (WMS) service provided layer abstract as the description.

_Note this may be unexpected in some applications_

[HTM-2106]: https://b3partners.atlassian.net/browse/HTM-2106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ