### PR TITLE
HTM-2133: Remove unused P6 Spy configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -693,7 +693,6 @@ SPDX-License-Identifier: MIT
                     <include>**/index.html</include>
                     <include>**/application*.properties</include>
                     <include>**/git.properties</include>
-                    <include>**/spy.properties</include>
                 </includes>
             </resource>
             <resource>
@@ -702,7 +701,6 @@ SPDX-License-Identifier: MIT
                     <exclude>**/index.html</exclude>
                     <exclude>**/application*.properties</exclude>
                     <exclude>**/git.properties</exclude>
-                    <exclude>**/spy.properties</exclude>
                 </excludes>
             </resource>
         </resources>
@@ -1534,7 +1532,6 @@ SPDX-License-Identifier: MIT
                                         <exclude>io.micrometer:micrometer-registry-prometheus</exclude>
                                         <exclude>io.micrometer:micrometer-core</exclude>
                                         <exclude>com.microsoft.sqlserver:mssql-jdbc:jar</exclude>
-                                        <exclude>p6spy:p6spy:jar</exclude>
                                         <!-- basically each and every geotools module has a load of transitive dependencies -->
                                         <exclude>org.geotools:*</exclude>
                                         <exclude>org.geotools.jdbc:*</exclude>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -126,7 +126,6 @@ spring.application.name=@project.artifactId@
 spring.datasource.url=jdbc:postgresql:tailormap
 spring.datasource.username=tailormap
 spring.datasource.password=tailormap
-#spring.datasource.driver-class-name=com.p6spy.engine.spy.P6SpyDriver
 spring.datasource.hikari.maximum-pool-size=30
 
 spring.session.jdbc.initialize-schema=always

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -1,2 +1,0 @@
-modulelist=com.p6spy.engine.spy.P6SpyFactory
-driverlist=org.postgresql.Driver


### PR DESCRIPTION
[![HTM-2133](https://badgen.net/badge/JIRA/HTM-2133/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2133) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

_to be rebased on main after merging https://github.com/Tailormap/tailormap-api/pull/1818_

[HTM-2133]: https://b3partners.atlassian.net/browse/HTM-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ