### PR TITLE
WIP HTM-2134: Update jackson-2-bom.version to 2.22.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ SPDX-License-Identifier: MIT
         <commons-codec.version>1.22.0</commons-codec.version>
         <flyway.version>12.10.0</flyway.version>
         <hibernate.version>7.4.3.Final</hibernate.version>
-        <jackson-2-bom.version>2.22.0</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <jackson-bom.version>3.1.4</jackson-bom.version>
         <json-path.version>3.0.0</json-path.version>
         <junit-jupiter.version>6.1.1</junit-jupiter.version>


### PR DESCRIPTION
[![HTM-2134](https://badgen.net/badge/JIRA/HTM-2134/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2134) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

We no longer use Jackson 2 in our code, but the Solrj library depends on it.

Fixes:
- https://github.com/Tailormap/tailormap-api/security/dependabot/48
- https://github.com/Tailormap/tailormap-api/security/code-scanning/579

- [ ] _wait for the 2.22.1 tag/release: https://github.com/FasterXML/jackson-bom/tags_ 

[HTM-2134]: https://b3partners.atlassian.net/browse/HTM-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ