### PR TITLE
HTM-2137: Add Tomcat version override to update to 11.0.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@ SPDX-License-Identifier: MIT
         <oracle-database.version>23.26.2.0.0</oracle-database.version>
         <postgresql.version>42.7.12</postgresql.version>
         <sqlite-jdbc.version>3.53.2.0</sqlite-jdbc.version>
+        <tomcat.version>11.0.23</tomcat.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>


### PR DESCRIPTION
[![HTM-2137](https://badgen.net/badge/JIRA/HTM-2137/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2137) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Tomcat 11.0.23 has fixed: CVE-2026-55276, CVE-2026-53434, CVE-2026-53404, CVE-2026-55956, CVE-2026-55955 

resolves:
- https://github.com/Tailormap/tailormap-api/security/code-scanning/580
- https://github.com/Tailormap/tailormap-api/security/code-scanning/581
- https://github.com/Tailormap/tailormap-api/security/code-scanning/583
- https://github.com/Tailormap/tailormap-api/security/code-scanning/582
- https://github.com/Tailormap/tailormap-api/security/code-scanning/584


[HTM-2137]: https://b3partners.atlassian.net/browse/HTM-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ