### PR TITLE
HTM-2092: Allow EWKT geometries in spatial filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ buildNumber.properties
 .run
 
 tailormap.log
+/*.qgz
+/*.qgs

--- a/build/qa/PMD-ruleset_for_TM.xml
+++ b/build/qa/PMD-ruleset_for_TM.xml
@@ -167,4 +167,26 @@ SPDX-License-Identifier: MIT
             </property>
         </properties>
     </rule>
+    <rule name="UseFilterUtil" language="java" message="Use FilterUtil.parseFilter instead of ECQL.toFilter"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+        <description>Don't use ECQL.toFilter(...), use FilterUtil.parseFilter(...) instead</description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+<!--
+//MethodCall[@MethodName='toFilter' and pmd-java:typeIs('org.geotools.filter.text.ecql.ECQL')]
+//Name[pmd-java:typeIs('org.geotools.filter.text.ecql.ECQL')]
+
+
+//MethodCall[pmd-java:matchesSig("org.geotools.filter.text.ecql.ECQL#toFilter()")]
+
+
+//MethodCall[@MethodName='toFilter'] and //Name[pmd-java:typeIs('org.geotools.filter.text.ecql.ECQL')]
+-->
+                <value><![CDATA[
+                //MethodCall[pmd-java:matchesSig('org.geotools.filter.text.ecql.ECQL#toFilter(java.lang.String)')]
+          ]]></value>
+            </property>
+        </properties>
+    </rule>
 </ruleset>

--- a/src/main/java/org/tailormap/api/controller/FeaturesController.java
+++ b/src/main/java/org/tailormap/api/controller/FeaturesController.java
@@ -32,7 +32,6 @@ import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.text.cql2.CQLException;
-import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.util.factory.GeoTools;
 import org.locationtech.jts.geom.Coordinate;
@@ -51,6 +50,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.server.ResponseStatusException;
 import org.tailormap.api.annotation.AppRestController;
+import org.tailormap.api.geotools.FilterUtil;
 import org.tailormap.api.geotools.TransformationUtil;
 import org.tailormap.api.geotools.featuresources.AttachmentsHelper;
 import org.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
@@ -170,6 +170,7 @@ public class FeaturesController implements Constants {
           filter,
           sortBy,
           sortOrder,
+          simplify,
           onlyGeometries,
           !geometryInAttributes,
           withAttachments);
@@ -189,6 +190,7 @@ public class FeaturesController implements Constants {
       String filterCQL,
       String sortBy,
       String sortOrder,
+      boolean simplifyGeometry,
       boolean onlyGeometries,
       boolean skipGeometryOutput,
       boolean withAttachments) {
@@ -255,7 +257,7 @@ public class FeaturesController implements Constants {
       // count can be -1 if too costly eg. some WFS
       int featureCount;
       if (null != filterCQL) {
-        Filter filter = ECQL.toFilter(filterCQL);
+        Filter filter = FilterUtil.parseFilter(filterCQL, application, fs);
         q.setFilter(filter);
         featureCount = fs.getCount(q);
         // this will execute the query twice, once to get the count and once to get the data
@@ -280,7 +282,7 @@ public class FeaturesController implements Constants {
       logger.debug("Attribute query: {}", q);
 
       executeQueryOnFeatureSourceAndClose(
-          false,
+          simplifyGeometry,
           featuresResponse,
           tmft,
           appLayerSettings,
@@ -292,9 +294,9 @@ public class FeaturesController implements Constants {
           withAttachments);
     } catch (IOException e) {
       logger.error("Could not retrieve attribute data.", e);
-    } catch (CQLException e) {
-      logger.error("Could not parse requested filter.", e);
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Could not parse requested filter");
+    } catch (CQLException | FactoryException | UnsupportedOperationException e) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Could not parse requested filter: " + e.getMessage(), e);
     } finally {
       if (fs != null) {
         fs.getDataStore().dispose();
@@ -392,7 +394,7 @@ public class FeaturesController implements Constants {
 
       Filter finalFilter = spatialFilter;
       if (null != filterCQL) {
-        Filter filter = ECQL.toFilter(filterCQL);
+        Filter filter = FilterUtil.parseFilter(filterCQL, application, fs);
         finalFilter = ff.and(spatialFilter, filter);
       }
       Query q = new Query(fs.getName().toString());
@@ -412,9 +414,9 @@ public class FeaturesController implements Constants {
           withAttachments);
     } catch (IOException e) {
       logger.error("Could not retrieve attribute data", e);
-    } catch (CQLException e) {
-      logger.error("Could not parse requested filter.", e);
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Could not parse requested filter");
+    } catch (CQLException | FactoryException | UnsupportedOperationException e) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Could not parse requested filter: " + e.getMessage(), e);
     }
     return featuresResponse;
   }

--- a/src/main/java/org/tailormap/api/controller/LayerBoundsController.java
+++ b/src/main/java/org/tailormap/api/controller/LayerBoundsController.java
@@ -12,17 +12,14 @@ import io.micrometer.core.annotation.Timed;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
-import java.util.regex.Pattern;
 import org.geotools.api.data.Query;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.operation.MathTransform;
 import org.geotools.data.oracle.OracleDialect;
 import org.geotools.data.postgis.PostGISDialect;
 import org.geotools.data.sqlserver.SQLServerDialect;
 import org.geotools.filter.text.cql2.CQLException;
-import org.geotools.filter.text.ecql.ECQL;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.jdbc.JDBCDataStore;
 import org.locationtech.jts.geom.Envelope;
@@ -38,6 +35,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.server.ResponseStatusException;
 import org.tailormap.api.annotation.AppRestController;
+import org.tailormap.api.geotools.FilterUtil;
 import org.tailormap.api.geotools.TransformationUtil;
 import org.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
 import org.tailormap.api.geotools.processing.GeometryProcessor;
@@ -95,32 +93,11 @@ public class LayerBoundsController {
 
       if (filterCQL != null && !filterCQL.isEmpty()) {
         try {
-          Filter parsedFilter = ECQL.toFilter(filterCQL);
-
-          // check if the application is in the same CRS as the feature type and we have a query that applies
-          // to the default geometry
-          MathTransform transform =
-              TransformationUtil.getTransformationToDataSource(application, featureSource);
-          String defaultGeom = tmft.getDefaultGeometryAttribute();
-          if (transform != null
-              && defaultGeom != null
-              // the filter CQL will contain something like "INTERSECTS(geom,..." so look for the
-              // opening '(' and closing ',' allowing whitespace so it is not too brittle wrt. formatting
-              // note that more than 1 spatial filters may be present, just look for any atm
-              && Pattern.compile("\\(\\s*" + Pattern.quote(defaultGeom) + "\\s*,")
-                  .matcher(filterCQL)
-                  .find()) {
-            // TODO https://b3partners.atlassian.net/browse/HTM-2088
-            //      we need to transform the geometry/geometries in the filter to the feature source CRS
-            //       before applying the filter, for now log a warning and continue
-            logger.warn(
-                "Application CRS is different from feature source CRS and filter '{}' contains spatial predicates on the default geometry, but filter geometries are not transformed. This will lead to incorrect results or errors.",
-                filterCQL);
-          }
-
+          Filter parsedFilter = FilterUtil.parseFilter(filterCQL, application, featureSource);
           query.setFilter(parsedFilter);
-        } catch (CQLException e) {
-          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        } catch (CQLException | FactoryException | UnsupportedOperationException e) {
+          throw new ResponseStatusException(
+              HttpStatus.BAD_REQUEST, "Could not parse requested filter: " + e.getMessage(), e);
         }
       }
 
@@ -142,7 +119,7 @@ public class LayerBoundsController {
       }
 
       // some datastores optimize getting bounds by using metadata or spatial index; this is inaccurate.
-      // Also featureSource.getBounds(query) can return null in case the GT API thinks it is too costly...
+      // Also, featureSource.getBounds(query) can return null in case the GT API thinks it is too costly...
       ReferencedEnvelope referencedEnvelope = featureSource.getBounds(query);
       if (referencedEnvelope == null) {
         referencedEnvelope = featureSource.getFeatures(query).getBounds();

--- a/src/main/java/org/tailormap/api/controller/LayerExtractController.java
+++ b/src/main/java/org/tailormap/api/controller/LayerExtractController.java
@@ -26,8 +26,8 @@ import org.geotools.api.data.Query;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortOrder;
+import org.geotools.api.referencing.FactoryException;
 import org.geotools.filter.text.cql2.CQLException;
-import org.geotools.filter.text.ecql.ECQL;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +47,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.server.ResponseStatusException;
 import org.tailormap.api.annotation.AppRestController;
+import org.tailormap.api.geotools.FilterUtil;
 import org.tailormap.api.geotools.data.excel.ExcelDataStore;
 import org.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
 import org.tailormap.api.persistence.Application;
@@ -201,14 +202,27 @@ public class LayerExtractController {
 
     // check if filter has valid syntax (it could still be invalid wrt feature type)
     Filter parsedCQL = null;
+    SimpleFeatureSource simpleFeatureSource = null;
     try {
       if (!StringUtils.isBlank(filter)) {
-        parsedCQL = ECQL.toFilter(filter);
+        simpleFeatureSource = featureSourceFactoryHelper.openGeoToolsFeatureSource(sourceFT);
+        parsedCQL = FilterUtil.parseFilter(filter, application, simpleFeatureSource);
       }
-    } catch (CQLException e) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid filter");
+    } catch (CQLException | FactoryException | UnsupportedOperationException e) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Could not parse requested filter: " + e.getMessage(), e);
+    } catch (IOException e) {
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR, "Failed to connect to datasource: " + e.getMessage(), e);
+    } finally {
+      if (simpleFeatureSource != null) {
+        try {
+          simpleFeatureSource.getDataStore().dispose();
+        } catch (Exception e) {
+          logger.warn("Failed to dispose feature source", e);
+        }
+      }
     }
-
     if (ExtractOutputFormat.XLSX.equals(outputFormat)) {
       validateExcelLimits(sourceFT, attributes, parsedCQL);
     }

--- a/src/main/java/org/tailormap/api/controller/UniqueValuesController.java
+++ b/src/main/java/org/tailormap/api/controller/UniqueValuesController.java
@@ -84,7 +84,7 @@ public class UniqueValuesController {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Attribute does not exist");
     }
     UniqueValuesResponse uniqueValuesResponse = UniqueValuesHelper.getUniqueValues(
-        tmft, attributeName, filter, ff, featureSourceFactoryHelper, useGeotoolsUniqueFunction);
+        app, tmft, attributeName, filter, ff, featureSourceFactoryHelper, useGeotoolsUniqueFunction);
     return ResponseEntity.status(HttpStatus.OK).body(uniqueValuesResponse);
   }
 }

--- a/src/main/java/org/tailormap/api/controller/admin/AttributeStatisticsAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/AttributeStatisticsAdminController.java
@@ -98,7 +98,7 @@ public class AttributeStatisticsAdminController {
       featureSource = featureSourceFactoryHelper.openGeoToolsFeatureSource(tmft);
       return ResponseEntity.ok()
           .body(FeatureSourceStatistics.getFeatureSourceStatistics(
-              featureSource, attributeName, filter, 10, null));
+              null, featureSource, attributeName, filter, 10, null));
     } catch (IllegalArgumentException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
     } catch (IOException e) {

--- a/src/main/java/org/tailormap/api/controller/admin/UniqueValuesAdminController.java
+++ b/src/main/java/org/tailormap/api/controller/admin/UniqueValuesAdminController.java
@@ -64,7 +64,7 @@ public class UniqueValuesAdminController {
   public ResponseEntity<Serializable> getUniqueValues(
       @PathVariable Long featureTypeId,
       @PathVariable String attributeName,
-      @RequestParam(required = false) String filter)
+      @RequestParam(required = false, name = "filter") String nonSpatialFilter)
       throws ResponseStatusException {
     if (StringUtils.isBlank(attributeName)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Attribute name is required");
@@ -84,7 +84,7 @@ public class UniqueValuesAdminController {
     }
 
     UniqueValuesResponse response = UniqueValuesHelper.getUniqueValues(
-        tmft, attributeName, filter, ff, featureSourceFactoryHelper, useGeotoolsUniqueFunction);
+        null, tmft, attributeName, nonSpatialFilter, ff, featureSourceFactoryHelper, useGeotoolsUniqueFunction);
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/src/main/java/org/tailormap/api/geotools/FilterUtil.java
+++ b/src/main/java/org/tailormap/api/geotools/FilterUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.geotools;
+
+import java.lang.invoke.MethodHandles;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.referencing.CRS;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tailormap.api.persistence.Application;
+
+public class FilterUtil {
+  private static final Pattern sridPattern = Pattern.compile("(?i)SRID=\\d+;");
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private FilterUtil() {
+    /* utility class */
+  }
+
+  /**
+   * Parses a CQL filter string into a GeoTools Filter, transforming geometries to the data source CRS if
+   * needed/possible.
+   *
+   * @param filterCQL the CQL filter string
+   * @param application the application context
+   * @param featureSource the feature source
+   * @return the parsed filter, with geometries transformed to the data source CRS if needed
+   * @throws CQLException if the filter cannot be parsed
+   * @throws FactoryException if there is an error with the CRS
+   * @throws UnsupportedOperationException if the filter SRID does not match the application CRS or different SRID
+   *     appear in the filter
+   */
+  @NonNull public static Filter parseFilter(
+      @NonNull String filterCQL, @NonNull Application application, @NonNull SimpleFeatureSource featureSource)
+      throws CQLException, FactoryException, UnsupportedOperationException {
+    @SuppressWarnings("PMD.UseFilterUtil")
+    Filter filter = ECQL.toFilter(filterCQL);
+    // if the filter is spatial/has EWKT geometries and the SRID is different from the data source
+    // we need to transform the geometries to the data source CRS
+    String foundSrid = null;
+    final Matcher sridMatcher = sridPattern.matcher(filterCQL);
+    while (sridMatcher.find()) {
+      // only support the EPSG authority for now, so we replace the SRID= with EPSG: and remove the trailing ;
+      String srid = sridMatcher.group().replaceAll("(?i)SRID=", "EPSG:").replace(";", "");
+      if (foundSrid == null) {
+        foundSrid = srid;
+      } else if (!foundSrid.equalsIgnoreCase(srid)) {
+        throw new UnsupportedOperationException("All SRIDs in filter must be identical");
+      }
+    }
+    if (foundSrid != null) {
+      logger.trace("Filter contains SRID, checking if transformation is needed");
+      CoordinateReferenceSystem dataSourceCRS = featureSource.getSchema().getCoordinateReferenceSystem();
+      CoordinateReferenceSystem filterCRS = CRS.decode(foundSrid);
+      CoordinateReferenceSystem appCRS = CRS.decode(application.getCrs());
+
+      if (!CRS.isEquivalent(appCRS, filterCRS)) {
+        // only support application CRS input
+        throw new UnsupportedOperationException("Filter SRID does not match application CRS");
+      }
+
+      if (!CRS.isEquivalent(dataSourceCRS, filterCRS)) {
+        MathTransform transform = TransformationUtil.getTransformationToDataSource(application, featureSource);
+        if (transform != null) {
+          filter = TransformationUtil.transformFilterGeometries(filter, transform);
+        }
+      }
+    }
+    return filter;
+  }
+}

--- a/src/main/java/org/tailormap/api/geotools/TransformationUtil.java
+++ b/src/main/java/org/tailormap/api/geotools/TransformationUtil.java
@@ -5,15 +5,34 @@
  */
 package org.tailormap.api.geotools;
 
-import jakarta.validation.constraints.NotNull;
+import java.lang.invoke.MethodHandles;
 import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterVisitor;
+import org.geotools.api.filter.spatial.Intersects;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.filter.LiteralExpressionImpl;
+import org.geotools.filter.spatial.IntersectsImpl;
+import org.geotools.filter.visitor.DefaultFilterVisitor;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.geometry.jts.WKTReader2;
 import org.geotools.referencing.CRS;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tailormap.api.persistence.Application;
 
 public class TransformationUtil {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final WKTReader2 wktReader = new WKTReader2();
+
   private TransformationUtil() {
     // utility class
   }
@@ -28,8 +47,8 @@ public class TransformationUtil {
    * @return {@code null} when no transform is required and a valid transform otherwise
    * @throws FactoryException when the CRS cannot be decoded
    */
-  public static MathTransform getTransformationToApplication(
-      @NotNull Application application, @NotNull SimpleFeatureSource simpleFeatureSource)
+  @Nullable public static MathTransform getTransformationToApplication(
+      @NonNull Application application, @NonNull SimpleFeatureSource simpleFeatureSource)
       throws FactoryException {
     // this is the CRS of the "default geometry" attribute
     final CoordinateReferenceSystem dataSourceCRS =
@@ -45,15 +64,15 @@ public class TransformationUtil {
   /**
    * Determine whether we need to transform geometry to data source crs. Note that this uses the "default geometry"
    * attribute of the feature source, in cases where a feature source has multiple geometry attributes (with possibly
-   * different CRSs) or heterogenous CRSs across a single geometry attribute this may not be accurate.
+   * different CRSs) or heterogeneous CRSs across a single geometry attribute this may not be accurate.
    *
    * @param application the referenced application
    * @param simpleFeatureSource the feature source used in the application
    * @return {@code null} when no transform is required and a valid transform otherwise
    * @throws FactoryException when the CRS cannot be decoded
    */
-  public static MathTransform getTransformationToDataSource(
-      @NotNull Application application, @NotNull SimpleFeatureSource simpleFeatureSource)
+  @Nullable public static MathTransform getTransformationToDataSource(
+      @NonNull Application application, @NonNull SimpleFeatureSource simpleFeatureSource)
       throws FactoryException {
     MathTransform transform = null;
     // this is the CRS of the "default geometry" attribute
@@ -64,5 +83,47 @@ public class TransformationUtil {
       transform = CRS.findMathTransform(appCRS, dataSourceCRS);
     }
     return transform;
+  }
+
+  /**
+   * Transforms the geometries in the given (intersects) spatial filter using the specified transformation.
+   *
+   * @param filter the spatial filter, currently only intersects filters are supported
+   * @param transform the transformation to apply
+   * @return the transformed filter
+   */
+  public static Filter transformFilterGeometries(@NonNull Filter filter, @Nullable MathTransform transform) {
+    if (transform != null) {
+      // Add transform for Intersects filter only, others not supported
+      FilterVisitor visitor = new DefaultFilterVisitor() {
+        @Override
+        public Object visit(Intersects filter, Object data) {
+          MathTransform transform = (MathTransform) data;
+          logger.trace("Transforming filter geometry with: {}", transform);
+          String geomWKT = filter.getExpression2().toString();
+          logger.trace("Input filter geometry: {}", geomWKT);
+          try {
+            Geometry geom = wktReader.read(geomWKT);
+            geom = JTS.transform(geom, transform);
+            logger.trace("Transformed filter geometry: {}", geom.toText());
+            if (filter instanceof IntersectsImpl intersectsImpl) {
+              intersectsImpl.setExpression2(new LiteralExpressionImpl(geom));
+            } else {
+              logger.warn(
+                  "Cannot update Intersects filter of type {}, leaving geometry untransformed. Filtered results will be inaccurate.",
+                  filter.getClass().getName());
+            }
+          } catch (ParseException | TransformException e) {
+            logger.error(
+                "Error transforming filter geometry: {}. Filtered results will be inaccurate.",
+                geomWKT,
+                e);
+          }
+          return data;
+        }
+      };
+      filter.accept(visitor, transform);
+    }
+    return filter;
   }
 }

--- a/src/main/java/org/tailormap/api/geotools/featuresources/FeatureSourceStatistics.java
+++ b/src/main/java/org/tailormap/api/geotools/featuresources/FeatureSourceStatistics.java
@@ -15,6 +15,7 @@ import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.feature.type.AttributeType;
 import org.geotools.api.filter.Filter;
+import org.geotools.api.referencing.FactoryException;
 import org.geotools.feature.visitor.AverageVisitor;
 import org.geotools.feature.visitor.CountVisitor;
 import org.geotools.feature.visitor.MaxVisitor;
@@ -26,7 +27,9 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.tailormap.api.geotools.FilterUtil;
 import org.tailormap.api.geotools.collection.ProgressReportingFeatureCollection;
+import org.tailormap.api.persistence.Application;
 import org.tailormap.api.viewer.model.AttributeStatisticsResponse;
 
 /** Calculate statistics (min/max/average/sum) and metadata (count) for an attribute of a feature source. */
@@ -54,6 +57,7 @@ public class FeatureSourceStatistics {
    */
   @SuppressWarnings("JavaUtilDate")
   @NonNull public static AttributeStatisticsResponse getFeatureSourceStatistics(
+      @Nullable Application application,
       @NonNull SimpleFeatureSource featureSource,
       @NonNull String attributeName,
       @Nullable String filterCQL,
@@ -84,10 +88,15 @@ public class FeatureSourceStatistics {
 
     if (filterCQL != null && !filterCQL.isEmpty()) {
       try {
-        Filter parsedFilter = ECQL.toFilter(filterCQL);
+        Filter parsedFilter;
+        if (application == null) {
+          parsedFilter = ECQL.toFilter(filterCQL); // NOPMD - admin usage does not have application context
+        } else {
+          parsedFilter = FilterUtil.parseFilter(filterCQL, application, featureSource);
+        }
         query.setFilter(parsedFilter);
         featureSourceStatistics.filterApplied(true);
-      } catch (CQLException e) {
+      } catch (CQLException | FactoryException | UnsupportedOperationException e) {
         logger.error("Invalid filter cql: {} ", filterCQL);
         throw new IllegalArgumentException("Could not parse requested filter", e);
       }

--- a/src/main/java/org/tailormap/api/persistence/helper/UniqueValuesHelper.java
+++ b/src/main/java/org/tailormap/api/persistence/helper/UniqueValuesHelper.java
@@ -15,13 +15,17 @@ import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.filter.expression.Function;
 import org.geotools.api.filter.sort.SortOrder;
+import org.geotools.api.referencing.FactoryException;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
+import org.tailormap.api.geotools.FilterUtil;
 import org.tailormap.api.geotools.featuresources.FeatureSourceFactoryHelper;
+import org.tailormap.api.persistence.Application;
 import org.tailormap.api.persistence.TMFeatureType;
 import org.tailormap.api.viewer.model.UniqueValuesResponse;
 
@@ -30,6 +34,7 @@ public class UniqueValuesHelper {
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static UniqueValuesResponse getUniqueValues(
+      @Nullable Application application,
       TMFeatureType tmft,
       String attributeName,
       String filter,
@@ -40,8 +45,13 @@ public class UniqueValuesHelper {
     SimpleFeatureSource fs = null;
     try {
       Filter existingFilter = null;
+      fs = featureSourceFactoryHelper.openGeoToolsFeatureSource(tmft);
       if (null != filter) {
-        existingFilter = ECQL.toFilter(filter);
+        if (application == null) {
+          existingFilter = ECQL.toFilter(filter); // NOPMD - admin usage does not have application context
+        } else {
+          existingFilter = FilterUtil.parseFilter(filter, application, fs);
+        }
       }
       logger.trace("existingFilter: {}", existingFilter);
 
@@ -57,7 +67,6 @@ public class UniqueValuesHelper {
       q.setSortBy(ff.sort(attributeName, SortOrder.ASCENDING));
       logger.trace("Unique values query: {}", q);
 
-      fs = featureSourceFactoryHelper.openGeoToolsFeatureSource(tmft);
       // and then there are 2 scenarios:
       // there might be a performance benefit for one or the other
       if (!useGeotoolsUniqueFunction) {
@@ -79,9 +88,10 @@ public class UniqueValuesHelper {
           uniqueValuesResponse.setValues(new TreeSet<>(uniqueValues));
         }
       }
-    } catch (CQLException e) {
+    } catch (CQLException | FactoryException | UnsupportedOperationException e) {
       logger.error("Could not parse requested filter", e);
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Could not parse requested filter");
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Could not parse requested filter: " + e.getMessage(), e);
     } catch (IOException e) {
       logger.error("Could not retrieve attribute data", e);
     } finally {

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -7,7 +7,10 @@ spring.web.error.include-stacktrace=always
 spring.web.error.include-message=always
 server.shutdown=immediate
 
-spring.jpa.show-sql=true
+# Only cleanup expired sessions every hour, instead of (default)
+#spring.session.jdbc.cleanup-cron=0 0 * * * *
+
+#spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.properties.hibernate.use_sql_comments=true
 #spring.jpa.properties.hibernate.enable_metrics=false

--- a/src/main/resources/openapi/viewer-api.yaml
+++ b/src/main/resources/openapi/viewer-api.yaml
@@ -839,6 +839,7 @@ paths:
           The filter is an ECQL string, see [ECQL reference](https://docs.geoserver.org/latest/en/user/filter/ecql_reference.html).
           Filtering is supported when requesting a page of features, not when requesting a single 
           feature (using `__fid`) nor when using x/y coordinates.
+          A spatial filter may use EWKT syntax (for example `SRID=28992;POLYGON(...)`), with the SRID equal to the application CRS.
           '
         in: query
         required: false
@@ -993,6 +994,7 @@ paths:
         description: '
         A filter that was already applied to the layer (on a different attribute or this attribute). 
         The filter is an ECQL string, see [ECQL reference](https://docs.geoserver.org/latest/en/user/filter/ecql_reference.html).
+          A spatial filter may use EWKT syntax (for example `SRID=28992;POLYGON(...)`), with the SRID equal to the application CRS.
         '
         in: query
         schema:
@@ -1178,7 +1180,7 @@ paths:
               type: object
               additionalProperties: true
               example:
-                CQL_FILTER: INTERSECTS(geom, BUFFER(POINT(1 2), 10))
+                CQL_FILTER: INTERSECTS(geom, POINT(1 2))
                 SLD_BODY: ...
       responses:
         '200':
@@ -1253,6 +1255,7 @@ paths:
           description: '
         A filter to be applied. The bounds will be calculated for the features that fulfill the filter. 
         The filter is an ECQL string, see [ECQL reference](https://docs.geoserver.org/latest/en/user/filter/ecql_reference.html).
+        A spatial filter may use EWKT syntax (for example `SRID=28992;POLYGON(...)`), with the SRID equal to the application CRS.
         '
           schema:
             type: string
@@ -1297,7 +1300,10 @@ paths:
               properties:
                 filter:
                   type: string
-                  description: 'A filter to be applied. The bounds will be calculated for the features that fulfill the filter. The filter is an ECQL string.'
+                  description: '
+                    A filter to be applied. The bounds will be calculated for the features that fulfill the filter. The filter is an ECQL string.
+                    A spatial filter may use EWKT syntax (for example `SRID=28992;POLYGON(...)`), with the SRID equal to the application CRS.
+                    '
       responses:
         '200':
           description: OK

--- a/src/test/java/org/tailormap/api/controller/FeaturesControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/FeaturesControllerIntegrationTest.java
@@ -226,6 +226,26 @@ class FeaturesControllerIntegrationTest {
             "creationdate after 2016-04-18T00:00:00Z and lv_publicatiedatum before 2019-11-20T17:09:52Z",
             // value depends on timezone, this is for Europe/Amsterdam. For UTC it is 1933.
             1963),
+        // attributes and spatial filter
+        arguments(
+            begroeidterreindeelUrlPostgis,
+            "(((creationdate BEFORE 2025-06-05T00:00:00.000Z) "
+                + "AND (plus_fysiekvoorkomen IN ('bodembedekkers','bosplantsoen','gras- en kruidachtigen'))) "
+                + "AND INTERSECTS(geom, POLYGON((130957.92 459473.76,130251.16 459329.34,130752.6 458663.66,130957.92 459473.76))))",
+            63),
+        // attributes and combined spatial filter
+        arguments(
+            begroeidterreindeelUrlPostgis,
+            "(((creationdate BEFORE 2025-06-05T00:00:00.000Z) "
+                + "AND (plus_fysiekvoorkomen IN ('bodembedekkers','bosplantsoen','gras- en kruidachtigen'))) "
+                + "AND INTERSECTS(geom, GEOMETRYCOLLECTION(POLYGON((130957.92 459473.76,130251.16 459329.34,130752.6 458663.66,130957.92 459473.76)),LINESTRING(130357.85 459641.55,130750.94 459685.97))))",
+            69),
+        arguments(
+            begroeidterreindeelUrlPostgis,
+            "(((creationdate BEFORE 2025-06-05T00:00:00.000Z) AND (plus_fysiekvoorkomen IN"
+                + " ('bodembedekkers','bosplantsoen','gras- en kruidachtigen'))) "
+                + "AND INTERSECTS(geom, SRID=28992;GEOMETRYCOLLECTION(POLYGON((130957.92 459473.76,130251.16 459329.34,130752.6 458663.66,130957.92 459473.76)),LINESTRING(130357.85 459641.55,130750.94 459685.97))))",
+            69),
         // (not) like / ilike
         arguments(begroeidterreindeelUrlPostgis, "class like 'grasland%'", 85),
         arguments(
@@ -415,7 +435,7 @@ class FeaturesControllerIntegrationTest {
   @WithMockUser(
       username = "tm-admin",
       authorities = {"admin"})
-  void should_return_empty_featurecollection_for_out_of_range_page_from_wfs() throws Exception {
+  void should_return_empty_feature_collection_for_out_of_range_page_from_wfs() throws Exception {
     // bestuurlijke gebieden WFS; provincies
     // page 3
     final String url = apiBasePath + provinciesWfs;
@@ -656,7 +676,7 @@ class FeaturesControllerIntegrationTest {
   @WithMockUser(
       username = "tm-admin",
       authorities = {"admin"})
-  void should_return_sorted_featurecollections_for_valid_sorting_from_database() throws Exception {
+  void should_return_sorted_feature_collections_for_valid_sorting_from_database() throws Exception {
     // begroeidterreindeel from postgis
     final String url = apiBasePath + begroeidterreindeelUrlPostgis;
     // page 1, sort ascending by gmlid
@@ -811,12 +831,12 @@ class FeaturesControllerIntegrationTest {
    */
   @ParameterizedTest(
       name =
-          "#{index}: should return non-empty featurecollections for valid page from database: {0}, featuretype: {1}")
+          "#{index}: should return non-empty feature collections for valid page from database: {0}, featuretype: {1}")
   @MethodSource("databaseArgumentsProvider")
   @WithMockUser(
       username = "tm-admin",
       authorities = {"admin"})
-  void should_return_non_empty_featurecollections_for_valid_pages_from_database(String applayerUrl, int totalCcount)
+  void should_return_non_empty_feature_collections_for_valid_pages_from_database(String applayerUrl, int totalCcount)
       throws Exception {
     applayerUrl = apiBasePath + applayerUrl;
     // page 1
@@ -929,6 +949,65 @@ class FeaturesControllerIntegrationTest {
         expected2ndCoordinate, g.getCoordinate().getY(), .1, "y coordinate should be " + expected2ndCoordinate);
   }
 
+  static Stream<Arguments> osmFiltersProvider() {
+    return Stream.of(
+        Arguments.of(
+            "INTERSECTS(way, SRID=28992;POLYGON((129284 461518,129282 460515,130150 461011,129284 461518)))",
+            2165,
+            5),
+        Arguments.of(
+            "((name ILIKE 'Maarssen') "
+                + "AND INTERSECTS(way, srid=28992;polygon((129284 461518,129282 460515,130150 461011,129284 461518))))",
+            1,
+            0));
+  }
+
+  @ParameterizedTest(name = "#{index}: should return non-empty feature collection for filter: {0} on OSM data")
+  @MethodSource("osmFiltersProvider")
+  void should_accept_foreign_spatial_and_attribute_filter_and_reproject(String filter, int total, int resultIndex)
+      throws Exception {
+    final String url = apiBasePath + osm_polygonUrlPostgis;
+
+    final String expectedFid = "osm_polygon.-310859";
+    final String expectedName = "Maarssen";
+    final double expected1stCoordinate = 128713.7;
+    final double expected2ndCoordinate = 461593.9;
+
+    MvcResult result = mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON)
+            .with(setServletPath(url))
+            .param("page", "1")
+            .param("simplify", "true")
+            .param("geometryInAttributes", "true")
+            .param("sortBy", "osm_id")
+            .param("filter", filter)
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.total").value(total))
+        .andExpect(jsonPath("$.features").isArray())
+        .andExpect(jsonPath("$.features").isNotEmpty())
+        .andExpectAll(
+            jsonPath("$.features[" + resultIndex + "]").isMap(),
+            jsonPath("$.features[" + resultIndex + "]").isNotEmpty(),
+            jsonPath("$.features[" + resultIndex + "].__fid").isNotEmpty(),
+            jsonPath("$.features[" + resultIndex + "].__fid").value(expectedFid),
+            jsonPath("$.features[" + resultIndex + "].geometry").isNotEmpty(),
+            jsonPath("$.features[" + resultIndex + "].attributes.boundary")
+                .value("administrative"),
+            jsonPath("$.features[" + resultIndex + "].attributes.name")
+                .value(expectedName))
+        .andReturn();
+
+    String body = result.getResponse().getContentAsString();
+    String geometry = JsonPath.read(body, "$.features[" + resultIndex + "].geometry");
+    Geometry g = new WKTReader().read(geometry);
+    assertEquals(Polygon.class, g.getClass(), "Did not find expected geometry type");
+    assertEquals(
+        expected1stCoordinate, g.getCoordinate().getX(), .1, "x coordinate should be " + expected1stCoordinate);
+    assertEquals(
+        expected2ndCoordinate, g.getCoordinate().getY(), .1, "y coordinate should be " + expected2ndCoordinate);
+  }
+
   @Test
   @DisplayName("should return expected polygon feature for valid coordinates from WFS")
   @WithMockUser(
@@ -982,12 +1061,12 @@ class FeaturesControllerIntegrationTest {
    * @throws Exception if any
    */
   @ParameterizedTest(
-      name = "#{index}: should return same featurecollection for same page from database: {0}, featuretype: {1}")
+      name = "#{index}: should return same feature collection for same page from database: {0}, featuretype: {1}")
   @MethodSource("databaseArgumentsProvider")
   @WithMockUser(
       username = "tm-admin",
       authorities = {"admin"})
-  void should_return_same_featurecollection_for_same_page_database(String applayerUrl, int totalCcount)
+  void should_return_same_feature_collection_for_same_page_database(String applayerUrl, int totalCount)
       throws Exception {
     applayerUrl = apiBasePath + applayerUrl;
 
@@ -998,7 +1077,7 @@ class FeaturesControllerIntegrationTest {
             .param("page", "1"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.total").value(totalCcount))
+        .andExpect(jsonPath("$.total").value(totalCount))
         .andExpect(jsonPath("$.page").value(1))
         .andExpect(jsonPath("$.pageSize").value(pageSize))
         .andExpect(jsonPath("$.features").isArray())
@@ -1023,7 +1102,7 @@ class FeaturesControllerIntegrationTest {
             .param("page", "1"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.total").value(totalCcount))
+        .andExpect(jsonPath("$.total").value(totalCount))
         .andExpect(jsonPath("$.page").value(1))
         .andExpect(jsonPath("$.pageSize").value(pageSize))
         .andExpect(jsonPath("$.features").isArray())
@@ -1051,12 +1130,13 @@ class FeaturesControllerIntegrationTest {
    * @throws Exception if any
    */
   @ParameterizedTest(
-      name = "#{index}: should return empty featurecollection for out of range page from database for layer: {0}")
+      name =
+          "#{index}: should return empty feature collection for out of range page from database for layer: {0}")
   @MethodSource("databaseArgumentsProvider")
   @WithMockUser(
       username = "tm-admin",
       authorities = {"admin"})
-  void should_return_empty_featurecollection_for_out_of_range_page_database(String appLayerUrl, int totalCount)
+  void should_return_empty_feature_collection_for_out_of_range_page_database(String appLayerUrl, int totalCount)
       throws Exception {
     appLayerUrl = apiBasePath + appLayerUrl;
     // request page ...
@@ -1081,7 +1161,7 @@ class FeaturesControllerIntegrationTest {
   }
 
   @ParameterizedTest(
-      name = "#{index} should return a featurecollection for various ECQL filters on appLayer: {0}, filter: {1}")
+      name = "#{index} should return a feature collection for various ECQL filters on appLayer: {0}, filter: {1}")
   @MethodSource("filtersProvider")
   @WithMockUser(
       username = "tm-admin",

--- a/src/test/java/org/tailormap/api/controller/LayerExtractControllerIntegrationTest.java
+++ b/src/test/java/org/tailormap/api/controller/LayerExtractControllerIntegrationTest.java
@@ -227,8 +227,8 @@ class LayerExtractControllerIntegrationTest extends SseParsingUtils {
             .characterEncoding(StandardCharsets.UTF_8)
             .contentType(MediaType.APPLICATION_FORM_URLENCODED))
         .andExpect(status().isBadRequest())
-        .andExpect(result ->
-            assertThat(result.getResponse().getContentAsString(), containsString("Invalid filter")));
+        .andExpect(result -> assertThat(
+            result.getResponse().getContentAsString(), containsString("Could not parse requested filter")));
   }
 
   @Test

--- a/src/test/java/org/tailormap/api/geotools/FilterUtilTest.java
+++ b/src/test/java/org/tailormap/api/geotools/FilterUtilTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package org.tailormap.api.geotools;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Answers.RETURNS_DEFAULTS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.Or;
+import org.geotools.api.filter.spatial.Intersects;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.filter.IsEqualsToImpl;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.tailormap.api.persistence.Application;
+
+class FilterUtilTest {
+
+  // Netherlands bounding box in RD New (EPSG:28992)
+  private static final String RD_NL_POLYGON =
+      "POLYGON((10000 306000, 280000 306000, 280000 640000, 10000 640000, 10000 306000))";
+
+  private static SimpleFeatureSource RDFeatureSource;
+
+  private static final Application RD_NL_APPLICATION = mock(Application.class, invocation -> {
+    if ("getCrs".equals(invocation.getMethod().getName())) {
+      return "EPSG:28992";
+    }
+    return RETURNS_DEFAULTS.answer(invocation);
+  });
+
+  @BeforeAll
+  static void setupMocks() throws FactoryException {
+    RDFeatureSource = mockFeatureSource("EPSG:28992");
+  }
+
+  private static SimpleFeatureSource mockFeatureSource(String crs) throws FactoryException {
+    SimpleFeatureSource featureSource = mock(SimpleFeatureSource.class);
+    SimpleFeatureType schema = mock(SimpleFeatureType.class);
+    when(featureSource.getSchema()).thenReturn(schema);
+    when(schema.getCoordinateReferenceSystem()).thenReturn(CRS.decode(crs));
+    return featureSource;
+  }
+
+  @Test
+  void non_spatial_filter_returns_parsed_filter() throws CQLException, FactoryException {
+    Filter filter = FilterUtil.parseFilter("name = 'test'", RD_NL_APPLICATION, RDFeatureSource);
+    assertNotNull(filter);
+    assertInstanceOf(IsEqualsToImpl.class, filter);
+    assertEquals("[ name = test ]", filter.toString());
+  }
+
+  @Test
+  void spatial_filter_same_crs_everywhere_no_transform() throws CQLException, FactoryException {
+    // filter SRID = app CRS = data source CRS → no transformation should occur
+    String cql = "INTERSECTS(geometry, SRID=28992;" + RD_NL_POLYGON + ")";
+    Filter filter = FilterUtil.parseFilter(cql, RD_NL_APPLICATION, RDFeatureSource);
+
+    assertNotNull(filter);
+    assertInstanceOf(Intersects.class, filter);
+    // geometry stays in RD New, so X coordinate is >> 10
+    Geometry geom = (Geometry) ((Intersects) filter).getExpression2().evaluate(null);
+    assertNotNull(geom);
+    assertTrue(geom.getCentroid().getX() > 10000, "X should be in RD New range (not WGS84 longitude)");
+  }
+
+  @Test
+  void spatial_filter_app_crs_matches_filter_srid_data_source_crs_differs_transform_applied()
+      throws CQLException, FactoryException {
+    // filter SRID = app CRS = EPSG:28992, data source = EPSG:3857 → geometry transformed to WGS84
+    SimpleFeatureSource featureSource = mockFeatureSource("EPSG:3857");
+
+    String cql = "INTERSECTS(geometry, SRID=28992;" + RD_NL_POLYGON + ")";
+    Filter filter = FilterUtil.parseFilter(cql, RD_NL_APPLICATION, featureSource);
+
+    assertNotNull(filter);
+    assertInstanceOf(Intersects.class, filter);
+
+    Geometry transformedGeom =
+        (Geometry) ((Intersects) filter).getExpression2().evaluate(null);
+    assertNotNull(transformedGeom);
+    // Netherlands in EPSG:3857:
+    // Minimum Bounds (South-West Corner): X: 388,275.01, Y: 6,594,835.97
+    // Maximum Bounds (North-East Corner): X: 775,208.11, Y: 7,025,835.01
+    double x = transformedGeom.getCentroid().getX();
+    double y = transformedGeom.getCentroid().getY();
+    assertThat(
+        "Longitude should be in Netherlands EPSG:3857 range, was: " + x,
+        x,
+        is(both(greaterThan(388275d)).and(lessThan(775208d))));
+    assertThat(
+        "Latitude should be in Netherlands EPSG:3857 range, was: " + y,
+        y,
+        is(both(greaterThan(6594835d)).and(lessThan(7025835d))));
+  }
+
+  @Test
+  void spatial_filter_srid_does_not_match_app_crs_throws() {
+    // filter SRID = EPSG:3857, app CRS = EPSG:28992 → must throw
+    String cql = "INTERSECTS(geometry, SRID=3857;POLYGON((3.3 51.5, 7.2 51.5, 7.2 53.5, 3.3 53.5, 3.3 51.5)))";
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> FilterUtil.parseFilter(cql, RD_NL_APPLICATION, RDFeatureSource));
+  }
+
+  @Test
+  void multiple_different_srids_in_filter_throws() {
+    String cql =
+        "INTERSECTS(geometry, SRID=28992;POINT(100000 400000)) OR INTERSECTS(geometry, SRID=3857;POINT(624339 6822408))";
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> FilterUtil.parseFilter(cql, RD_NL_APPLICATION, RDFeatureSource));
+  }
+
+  @Test
+  void multiple_same_srids_in_filter_succeeds() throws CQLException, FactoryException {
+    // Two INTERSECTS with identical SRIDs → no exception
+    String cql =
+        "INTERSECTS(geometry, SRID=28992;POINT(100000 400000)) OR INTERSECTS(geometry, SRID=28992;POINT(200000 500000))";
+
+    Filter filter = FilterUtil.parseFilter(cql, RD_NL_APPLICATION, RDFeatureSource);
+    assertNotNull(filter);
+    assertInstanceOf(Or.class, filter, "Filter should be an Or filter");
+  }
+
+  @Test
+  void invalid_cql_throws_cql_exception() {
+    assertThrows(
+        CQLException.class,
+        () -> FilterUtil.parseFilter("NOT VALID CQL !!!", RD_NL_APPLICATION, RDFeatureSource));
+  }
+}

--- a/src/test/java/org/tailormap/api/geotools/featuresources/FeatureSourceStatisticsTest.java
+++ b/src/test/java/org/tailormap/api/geotools/featuresources/FeatureSourceStatisticsTest.java
@@ -66,7 +66,7 @@ class FeatureSourceStatisticsTest {
   void get_number_statistics() {
     AtomicInteger progressCount = new AtomicInteger(0);
     AttributeStatisticsResponse statistics = FeatureSourceStatistics.getFeatureSourceStatistics(
-        randomFeatureSource, "randomNumber", null, 10, progressCount::set);
+        null, randomFeatureSource, "randomNumber", null, 10, progressCount::set);
 
     assertFalse(statistics.getFilterApplied());
     assertNotNull(statistics.getMin());
@@ -84,7 +84,7 @@ class FeatureSourceStatisticsTest {
   void get_number_statistics_with_filter() {
     AtomicInteger progressCount = new AtomicInteger(0);
     AttributeStatisticsResponse statistics = FeatureSourceStatistics.getFeatureSourceStatistics(
-        randomFeatureSource, "randomNumber", "randomNumber < 500", 10, progressCount::set);
+        null, randomFeatureSource, "randomNumber", "randomNumber < 500", 10, progressCount::set);
 
     assertTrue(statistics.getFilterApplied());
     assertNotNull(statistics.getMin());
@@ -104,7 +104,7 @@ class FeatureSourceStatisticsTest {
   void get_date_statistics() {
     AtomicInteger progressCount = new AtomicInteger(0);
     AttributeStatisticsResponse statistics = FeatureSourceStatistics.getFeatureSourceStatistics(
-        randomFeatureSource, "date", null, 10, progressCount::set);
+        null, randomFeatureSource, "date", null, 10, progressCount::set);
 
     assertFalse(statistics.getFilterApplied());
     assertNotNull(statistics.getMin());
@@ -135,7 +135,7 @@ class FeatureSourceStatisticsTest {
         .toLocalDate()
         .toEpochDay();
     AttributeStatisticsResponse statistics = FeatureSourceStatistics.getFeatureSourceStatistics(
-        randomFeatureSource, "localdate", null, 10, progressCount::set);
+        null, randomFeatureSource, "localdate", null, 10, progressCount::set);
 
     assertFalse(statistics.getFilterApplied());
     assertNotNull(statistics.getMin());
@@ -160,7 +160,7 @@ class FeatureSourceStatisticsTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> FeatureSourceStatistics.getFeatureSourceStatistics(
-            randomFeatureSource, "location", null, 10, null));
+            null, randomFeatureSource, "location", null, 10, null));
   }
 
   @Test
@@ -168,7 +168,7 @@ class FeatureSourceStatisticsTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> FeatureSourceStatistics.getFeatureSourceStatistics(
-            randomFeatureSource, "does-not-exist", null, 10, null));
+            null, randomFeatureSource, "does-not-exist", null, 10, null));
   }
 
   @Test
@@ -176,6 +176,6 @@ class FeatureSourceStatisticsTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> FeatureSourceStatistics.getFeatureSourceStatistics(
-            randomFeatureSource, "randomNumber", "randomNumber == 'invalid", 10, null));
+            null, randomFeatureSource, "randomNumber", "randomNumber == 'invalid", 10, null));
   }
 }


### PR DESCRIPTION
[![HTM-2092](https://badgen.net/badge/JIRA/HTM-2092/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2092) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This should make endpoints accepting a spatial filter work for datasets that are not in the application CRS, assuming filter geometries are submitted in EWKT format.
For now only application-CRS matching EWKT is accepted 

See also: https://github.com/Tailormap/tailormap-viewer/pull/1416 

[HTM-2092]: https://b3partners.atlassian.net/browse/HTM-2092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ