### PR TITLE
HTM-2204: Override log4j2 version, bump to 2.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,8 @@ SPDX-License-Identifier: MIT
         <jackson-bom.version>3.1.5</jackson-bom.version>
         <json-path.version>3.0.0</json-path.version>
         <junit-jupiter.version>6.1.2</junit-jupiter.version>
+        <!-- fix HTM-2204 / CVE-2026-49844, override can probably be removed after updating spring boot to 4.0.8 or 4.1.1-->
+        <log4j2.version>2.25.5</log4j2.version>
         <micrometer.version>1.17.0</micrometer.version>
         <mockito.version>5.23.0</mockito.version>
         <mssql-jdbc.version>13.4.0.jre11</mssql-jdbc.version>


### PR DESCRIPTION
[![HTM-2204](https://badgen.net/badge/JIRA/HTM-2204/7A54FF?icon=jira)](https://b3partners.atlassian.net/browse/HTM-2204) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Tailormap&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

fixes CVE-2026-49844 Improper Encoding or Escaping of Output vulnerability 

resolves https://github.com/Tailormap/tailormap-api/security/code-scanning/596

[HTM-2204]: https://b3partners.atlassian.net/browse/HTM-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ